### PR TITLE
Add Mac OS Support

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,7 +1,9 @@
 *.so*
 *.dll
+*.dylib
 *.pyd
 pyluxcoretools.zip
 pyluxcoretool.exe
 luxcoreui
 luxcoreui.exe
+

--- a/bin/get_binaries.py
+++ b/bin/get_binaries.py
@@ -16,6 +16,12 @@ WINDOWS_FILES = [
     "pyluxcoretool.exe", "pyluxcoretools.zip",
 ]
 
+MAC_FILES = [
+    "libembree3.dylib", "libembree3.3.dylib", "libtbb.dylib",
+    "libtbbmalloc.dylib", "pyluxcore.so", "luxcoreui",
+    "pyluxcoretools.zip", "libomp.dylib",
+]
+
 
 def confirm(message):
     while True:
@@ -38,6 +44,8 @@ def main():
         files = LINUX_FILES
     elif platform.system() == "Windows":
         files = WINDOWS_FILES
+    elif platform.system() == "Darwin":
+        files = MAC_FILES
     else:
         print("Unsupported system:", platform.system())
 

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -2,6 +2,14 @@ import webbrowser
 
 import bpy
 from bpy.props import StringProperty, BoolProperty
+from platform import system
+from os import environ
+
+#Fix problem of OpenMP calling a trap about two libraries loading because blender's
+#openmp lib uses @loader_path and zip does not preserve symbolic links (so can't
+#spoof loader_path with symlinks)
+if system() == "Darwin":
+    environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
 # Ensure initialization (note: no need to initialize utils)
 from . import (

--- a/operators/update.py
+++ b/operators/update.py
@@ -126,6 +126,7 @@ class LUXCORE_OT_change_version(bpy.types.Operator):
         system_mapping = {
             "Linux": "linux64",
             "Windows": "win64",
+            "Darwin": "mac64"
         }
         try:
             current_system = system_mapping[platform.system()]


### PR DESCRIPTION
This pull request adds Mac OS support for BlendLuxCore. 

This pull request does not include updates to `release/package_releases.py` because a release of LuxCore MacOS has not been made yet. Once a MacOS release is cut in the LuxCore repo a second PR will be made for adding to the release process here.