### PR TITLE
Extra image pipeline for adaptive sampling

### DIFF
--- a/export/aovs.py
+++ b/export/aovs.py
@@ -266,20 +266,13 @@ def _make_noise_detection_imagepipeline(context, scene, props, engine, pipeline_
     prefix = "film.imagepipelines." + str(pipeline_index) + "."
     definitions = OrderedDict()
 
-    # Index is the plugin index, needed only if you want to insert plugins before/after all other plugins of this pipeline
     index = 0
     index = imagepipeline.convert_defs(context, scene, definitions, index, define_radiancescales=True)
     definitions['{}.type'.format(index)] = 'GAMMA_CORRECTION'
     definitions['{}.value'.format(index)] = 2.2
-    # if you don't need the index, you can also write:
-    #   imagepipeline.convert_defs(context, scene, definitions, 0, define_radiancescales=True)
+
     props.Set(utils.create_props(prefix, definitions))
     _add_output(output_definitions, "RGB_IMAGEPIPELINE", pipeline_index)
 
-    # For debugging
-    print("Noise detection pipeline created with index:", pipeline_index)
-    print('context: ', context)
-    print('scene: ', scene)
-    print('definitions: ', definitions)
 
     return pipeline_index + 1

--- a/export/aovs.py
+++ b/export/aovs.py
@@ -120,9 +120,9 @@ def convert(exporter, scene, context=None, engine=None):
                 pipeline_index = _make_denoiser_imagepipeline(context, scene, pipeline_props, engine,
                                                               pipeline_index, definitions)
                                                               
-            using_adaptive_sampler = True  # TODO check if adaptive sampling is enabled
-                                           # with something like (config.sampler in {"SOBOL", "RANDOM"} and config.sobol_adaptive_strength > 0)
-            if using_adaptive_sampler:
+            config = scene.luxcore.config
+            if config.sampler in ["SOBOL", "RANDOM"] and config.sobol_adaptive_strength > 0:
+                
                 pipeline_index = _make_noise_detection_imagepipeline(context, scene, pipeline_props, engine,
                                                                      pipeline_index, definitions)
 

--- a/export/aovs.py
+++ b/export/aovs.py
@@ -277,7 +277,7 @@ def _make_noise_detection_imagepipeline(context, scene, props, engine, pipeline_
     _add_output(output_definitions, "RGB_IMAGEPIPELINE", pipeline_index)
 
     # For debugging
-git p    print("Noise detection pipeline created with index:", pipeline_index)
+    print("Noise detection pipeline created with index:", pipeline_index)
     print('context: ', context)
     print('scene: ', scene)
     print('definitions: ', definitions)

--- a/export/aovs.py
+++ b/export/aovs.py
@@ -121,13 +121,18 @@ def convert(exporter, scene, context=None, engine=None):
                                                               pipeline_index, definitions)
                                                               
             config = scene.luxcore.config
-            if config.sampler in ["SOBOL", "RANDOM"] and config.sobol_adaptive_strength > 0:
-                
+            use_adaptive_sampling = True if config.sampler in ["SOBOL", "RANDOM"] and config.sobol_adaptive_strength > 0 else False
+
+            if use_adaptive_sampling:
+                adaptive_sampling_film_pipeline_index = pipeline_index
                 pipeline_index = _make_noise_detection_imagepipeline(context, scene, pipeline_props, engine,
                                                                      pipeline_index, definitions)
 
         props = utils.create_props(prefix, definitions)
         props.Set(pipeline_props)
+
+        if use_adaptive_sampling:
+            props.Set(pyluxcore.Property("film.noiseestimation.index", adaptive_sampling_film_pipeline_index))
 
         return props
     except Exception as error:

--- a/export/config.py
+++ b/export/config.py
@@ -268,7 +268,6 @@ def _convert_final_engine(scene, definitions, config):
             definitions["film.noiseestimation.step"] = config.noise_estimation.step
         definitions["sampler.sobol.adaptive.strength"] = adaptive_strength
         definitions["sampler.random.adaptive.strength"] = adaptive_strength
-        definitions["film.noiseestimation.index"] = 1
         _convert_metropolis_settings(definitions, config)
 
     return luxcore_engine, sampler

--- a/export/config.py
+++ b/export/config.py
@@ -268,6 +268,7 @@ def _convert_final_engine(scene, definitions, config):
             definitions["film.noiseestimation.step"] = config.noise_estimation.step
         definitions["sampler.sobol.adaptive.strength"] = adaptive_strength
         definitions["sampler.random.adaptive.strength"] = adaptive_strength
+        definitions["film.noiseestimation.index"] = 1
         _convert_metropolis_settings(definitions, config)
 
     return luxcore_engine, sampler


### PR DESCRIPTION
Hi,

This is for conditionally adding an extra image pipeline in case the adaptive sampler is used.
Might cause some issues with the Blender color pipeline, in the sense that some regions might be under/oversampler due to a mismatch between what the sampler "sees" and what is shown in Blender.

This is, however, already the case and I would expect that Gamma correcting it would bring it closer than the current solution

The part that I implemented the conditional for changing the image pipeline index is a bit spaghetty, so let me know if you have a better solution
