### PR TITLE
Fix light emission when Power or Efficacy = 0

### DIFF
--- a/export/light.py
+++ b/export/light.py
@@ -96,7 +96,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.use_advanced:
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
-            definitions["gain"] = [1, 1, 1]
+            # Set Gain to 0 if Power or Efficacy is 0
+            if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                definitions["gain"] = [0, 0, 0]
+            else:
+                definitions["gain"] = [1, 1, 1]
+
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
@@ -169,7 +174,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.use_advanced:
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
-            definitions["gain"] = [1, 1, 1]
+            # Set Gain to 0 if Power or Efficacy is 0
+            if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                definitions["gain"] = [0, 0, 0]
+            else:
+                definitions["gain"] = [1, 1, 1]
+
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
@@ -193,7 +203,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
             if light.luxcore.use_advanced:
                 definitions["efficency"] = light.luxcore.efficacy
                 definitions["power"] = light.luxcore.power
-                definitions["gain"] = [1, 1, 1]
+                # Set Gain to 0 if Power or Efficacy is 0
+                if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                    definitions["gain"] = [0, 0, 0]
+                else:
+                    definitions["gain"] = [1, 1, 1]
+
             else:
                 definitions["efficency"] = 0.0
                 definitions["power"] = 0.0
@@ -375,7 +390,11 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
     if light.luxcore.use_advanced:
         mat_definitions["emission.power"] = light.luxcore.power
         mat_definitions["emission.efficency"] = light.luxcore.efficacy
-        mat_definitions["emission.gain"] = [1, 1, 1]
+        # Set Gain to 0 if Power or Efficacy is 0
+        if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+            mat_definitions["emission.gain"] = [0, 0, 0]
+        else:
+            mat_definitions["emission.gain"] = [1, 1, 1]
 
     node_tree = light.luxcore.node_tree
     if node_tree is not None:

--- a/nodes/materials/emission.py
+++ b/nodes/materials/emission.py
@@ -119,6 +119,8 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
         if self.use_advanced:
             definitions["emission.power"] = self.power
             definitions["emission.efficency"] = self.efficacy
+            if self.power == 0 or self.efficacy == 0:
+                definitions["emission.gain"] = 0
         else:
             definitions["emission.power"] = 0
             definitions["emission.efficency"] = 0


### PR DESCRIPTION
This is to fix light emission when using Advanced mode for light units. LuxCore uses Gain value when Power or Efficacy = 0, instead of turning off the light.