### PR TITLE
Adding Light Unit and Exposure setting to lights

### DIFF
--- a/export/light.py
+++ b/export/light.py
@@ -96,7 +96,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.use_advanced:
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
-            definitions["gain"] = [1, 1, 1]
+            # Set Gain to 0 if Power or Efficacy is 0
+            if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                definitions["gain"] = [0, 0, 0]
+            else:
+                definitions["gain"] = [1, 1, 1]
+
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
@@ -169,7 +174,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.use_advanced:
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
-            definitions["gain"] = [1, 1, 1]
+            # Set Gain to 0 if Power or Efficacy is 0
+            if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                definitions["gain"] = [0, 0, 0]
+            else:
+                definitions["gain"] = [1, 1, 1]
+
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
@@ -193,7 +203,12 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
             if light.luxcore.use_advanced:
                 definitions["efficency"] = light.luxcore.efficacy
                 definitions["power"] = light.luxcore.power
-                definitions["gain"] = [1, 1, 1]
+                # Set Gain to 0 if Power or Efficacy is 0
+                if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+                    definitions["gain"] = [0, 0, 0]
+                else:
+                    definitions["gain"] = [1, 1, 1]
+
             else:
                 definitions["efficency"] = 0.0
                 definitions["power"] = 0.0
@@ -375,7 +390,11 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
     if light.luxcore.use_advanced:
         mat_definitions["emission.power"] = light.luxcore.power
         mat_definitions["emission.efficency"] = light.luxcore.efficacy
-        mat_definitions["emission.gain"] = [1, 1, 1]
+        # Set Gain to 0 if Power or Efficacy is 0
+        if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
+            mat_definitions["emission.gain"] = [0, 0, 0]
+        else:
+            mat_definitions["emission.gain"] = [1, 1, 1]
 
     node_tree = light.luxcore.node_tree
     if node_tree is not None:

--- a/export/light.py
+++ b/export/light.py
@@ -51,7 +51,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
     # Common light settings shared by all light types
     # Note: these variables are also passed to the area light export function
     gain, importance, lightgroup_id = _convert_common_props(exporter, scene, light)
-    definitions["gain"] = gain
+    definitions["gain"] = [x * pow(2, light.luxcore.exposure) for x in gain]
     definitions["importance"] = importance
     definitions["id"] = lightgroup_id
 
@@ -75,7 +75,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
                     # Fallback
                     definitions["type"] = "point" if light.shadow_soft_size == 0 else "sphere"
                     # Signal that the image is missing
-                    definitions["gain"] = [x * light.luxcore.gain for x in MISSING_IMAGE_COLOR]
+                    definitions["gain"] = [x * light.luxcore.gain * pow(2, light.luxcore.exposure) for x in MISSING_IMAGE_COLOR]
 
             has_ies = False
             try:
@@ -93,7 +93,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
 
         definitions["color"] = [x for x in light.luxcore.rgb_gain]
 
-        if light.luxcore.use_advanced:
+        if light.luxcore.light_unit == "power":
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
             # Set Gain to 0 if Power or Efficacy is 0
@@ -162,7 +162,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
                 # Fallback
                 definitions["type"] = "spot"
                 # Signal that the image is missing
-                definitions["gain"] = [x * light.luxcore.gain for x in MISSING_IMAGE_COLOR]
+                definitions["gain"] = [x * light.luxcore.gain * pow(2, light.luxcore.exposure) for x in MISSING_IMAGE_COLOR]
         else:
             # spot
             definitions["type"] = "spot"
@@ -171,7 +171,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
 
         definitions["color"] = [x for x in light.luxcore.rgb_gain]
 
-        if light.luxcore.use_advanced:
+        if light.luxcore.light_unit == "power":
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
             # Set Gain to 0 if Power or Efficacy is 0
@@ -200,7 +200,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
 
             definitions["color"] = [x for x in light.luxcore.rgb_gain]
 
-            if light.luxcore.use_advanced:
+            if light.luxcore.light_unit == "power":
                 definitions["efficency"] = light.luxcore.efficacy
                 definitions["power"] = light.luxcore.power
                 # Set Gain to 0 if Power or Efficacy is 0
@@ -246,7 +246,7 @@ def convert_world(exporter, world, scene, is_viewport_render):
         definitions = {}
 
         gain, importance, lightgroup_id = _convert_common_props(exporter, scene, world)
-        definitions["gain"] = gain
+        definitions["gain"] = [x * pow(2, world.luxcore.exposure) for x in gain]
         definitions["importance"] = importance
         definitions["id"] = lightgroup_id
 
@@ -261,7 +261,7 @@ def convert_world(exporter, world, scene, is_viewport_render):
                 definitions["dir"] = _calc_sun_dir(world.luxcore.sun.matrix_world)
 
                 if world.luxcore.use_sun_gain_for_sky:
-                    gain = [x * world.luxcore.sun.data.luxcore.gain for x in world.luxcore.rgb_gain]
+                    gain = [x * world.luxcore.sun.data.luxcore.gain * pow(2, world.luxcore.sun.data.luxcore.exposure) for x in world.luxcore.rgb_gain]
                     definitions["gain"] = gain
 
             if world.luxcore.sun and world.luxcore.sun.data:
@@ -373,7 +373,7 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
         # Black base material to avoid any bounce light from the mesh
         "kd": [0, 0, 0],
         "emission": [x for x in light.luxcore.rgb_gain],
-        "emission.gain": gain,
+        "emission.gain": [x * pow(2, light.luxcore.exposure) for x in gain],
         "emission.power": 0.0,
         "emission.efficency": 0.0,
         "emission.theta": math.degrees(light.luxcore.spread_angle),
@@ -387,7 +387,7 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
         "visibility.indirect.specular.enable": light.luxcore.visibility_indirect_specular,
     }
 
-    if light.luxcore.use_advanced:
+    if light.luxcore.light_unit == "power":
         mat_definitions["emission.power"] = light.luxcore.power
         mat_definitions["emission.efficency"] = light.luxcore.efficacy
         # Set Gain to 0 if Power or Efficacy is 0

--- a/export/light.py
+++ b/export/light.py
@@ -51,7 +51,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
     # Common light settings shared by all light types
     # Note: these variables are also passed to the area light export function
     gain, importance, lightgroup_id = _convert_common_props(exporter, scene, light)
-    definitions["gain"] = [x * pow(2, light.luxcore.exposure) for x in gain]
+    definitions["gain"] = apply_exposure(gain, light.luxcore.exposure)
     definitions["importance"] = importance
     definitions["id"] = lightgroup_id
 
@@ -246,7 +246,7 @@ def convert_world(exporter, world, scene, is_viewport_render):
         definitions = {}
 
         gain, importance, lightgroup_id = _convert_common_props(exporter, scene, world)
-        definitions["gain"] = [x * pow(2, world.luxcore.exposure) for x in gain]
+        definitions["gain"] = apply_exposure(gain, world.luxcore.exposure)
         definitions["importance"] = importance
         definitions["id"] = lightgroup_id
 
@@ -373,7 +373,7 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
         # Black base material to avoid any bounce light from the mesh
         "kd": [0, 0, 0],
         "emission": [x for x in light.luxcore.rgb_gain],
-        "emission.gain": [x * pow(2, light.luxcore.exposure) for x in gain],
+        "emission.gain": apply_exposure(gain, light.luxcore.exposure),
         "emission.power": 0.0,
         "emission.efficency": 0.0,
         "emission.theta": math.degrees(light.luxcore.spread_angle),
@@ -518,6 +518,8 @@ def _envlightcache(definitions, light_or_world, scene):
         definitions["visibilitymapcache.map.samplecount"] = envlight_cache.samples
         definitions["visibilitymapcache.map.sampleupperhemisphereonly"] = light_or_world.luxcore.sampleupperhemisphereonly
 
+def apply_exposure(gain, exposure):
+    return [x * pow(2, exposure) for x in gain]
 
 def export_ies(definitions, ies, library, is_meshlight=False):
     """

--- a/nodes/materials/emission.py
+++ b/nodes/materials/emission.py
@@ -119,6 +119,8 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
         if self.use_advanced:
             definitions["emission.power"] = self.power
             definitions["emission.efficency"] = self.efficacy
+            if self.power == 0 or self.efficacy == 0:
+                definitions["emission.gain"] = 0
         else:
             definitions["emission.power"] = 0
             definitions["emission.efficency"] = 0

--- a/nodes/materials/emission.py
+++ b/nodes/materials/emission.py
@@ -42,9 +42,10 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
     emission_units = [ ("artistic", "Artistic", "Artist friendly unit using Gain and Exposure"),  
         ("power", "Power", "Radiant flux in Watts")
     ]
-    emission_unit: EnumProperty(name="Unit", items=emission_units, default="artistic")
+    emission_unit: EnumProperty(update=utils_node.force_viewport_update, name="Unit", items=emission_units, default="artistic")
     gain: FloatProperty(update=utils_node.force_viewport_update, name="Gain", default=1, min=0, description="Brightness multiplier")
-    exposure: FloatProperty(name="Exposure", default=0, soft_min=-10, soft_max=10, precision=2, description="Power-of-2 step multiplier. An EV step of 1 will double the brightness of the light")
+    exposure: FloatProperty(update=utils_node.force_viewport_update, name="Exposure", default=0, soft_min=-10, soft_max=10, precision=2,
+                            description="Power-of-2 step multiplier. An EV step of 1 will double the brightness of the light")
     power: FloatProperty(update=utils_node.force_viewport_update, name="Power (W)", default=100, min=0, description=POWER_DESCRIPTION)
     efficacy: FloatProperty(update=utils_node.force_viewport_update, name="Efficacy (lm/W)", default=17, min=0, description=EFFICACY_DESCRIPTION)
     ies: PointerProperty(update=utils_node.force_viewport_update, type=LuxCoreIESProps)

--- a/nodes/materials/emission.py
+++ b/nodes/materials/emission.py
@@ -39,8 +39,12 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
     bl_label = "Emission"
     bl_width_default = 160
 
+    emission_units = [ ("artistic", "Artistic", "Artist friendly unit using Gain and Exposure"),  
+        ("power", "Power", "Radiant flux in Watts")
+    ]
+    emission_unit: EnumProperty(name="Unit", items=emission_units, default="artistic")
     gain: FloatProperty(update=utils_node.force_viewport_update, name="Gain", default=1, min=0, description="Brightness multiplier")
-    use_advanced: BoolProperty(name="Advanced", default=False)
+    exposure: FloatProperty(name="Exposure", default=0, soft_min=-10, soft_max=10, precision=2, description="Power-of-2 step multiplier. An EV step of 1 will double the brightness of the light")
     power: FloatProperty(update=utils_node.force_viewport_update, name="Power (W)", default=100, min=0, description=POWER_DESCRIPTION)
     efficacy: FloatProperty(update=utils_node.force_viewport_update, name="Efficacy (lm/W)", default=17, min=0, description=EFFICACY_DESCRIPTION)
     ies: PointerProperty(update=utils_node.force_viewport_update, type=LuxCoreIESProps)
@@ -66,13 +70,14 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
 
     def draw_buttons(self, context, layout):
         col = layout.column(align=True)
-        col.prop(self, "use_advanced")
+        col.prop(self, "emission_unit")
         col = layout.column(align=True)
-        if self.use_advanced:
+        if self.emission_unit == "power":
             col.prop(self, "power")
             col.prop(self, "efficacy")
         else:
             col.prop(self, "gain")
+            col.prop(self, "exposure", slider=True)
 
         layout.prop(self, "importance")
 
@@ -116,15 +121,15 @@ class LuxCoreNodeMatEmission(bpy.types.Node, LuxCoreNode):
         It is called from LuxCoreNodeMaterial.export_common_props()
         """
         definitions["emission"] = self.inputs["Color"].export(exporter, depsgraph, props)
-        if self.use_advanced:
+        if self.emission_unit == "power":
             definitions["emission.power"] = self.power
             definitions["emission.efficency"] = self.efficacy
             if self.power == 0 or self.efficacy == 0:
-                definitions["emission.gain"] = 0
+                definitions["emission.gain"] = [0,0,0]
         else:
             definitions["emission.power"] = 0
             definitions["emission.efficency"] = 0
-            definitions["emission.gain"] = [self.gain] * 3
+            definitions["emission.gain"] = [self.gain * pow(2, self.exposure)] * 3
         definitions["emission.importance"] = self.importance
         definitions["emission.theta"] = math.degrees(self.spread_angle)
         lightgroups = exporter.scene.luxcore.lightgroups

--- a/properties/light.py
+++ b/properties/light.py
@@ -24,6 +24,11 @@ POWER_DESCRIPTION = (
     "this feature and uses only the light gain"
 )
 
+EXPOSURE_DESCRIPTION = (
+    "Power-of-2 step multiplier. "
+    "An EV step of 1 will double the brightness of the light"
+)
+
 EFFICACY_DESCRIPTION = (
     "Luminous efficacy in lumens per watt; setting 0 for both power "
     "and efficacy bypasses this feature and uses only the light gain"
@@ -95,6 +100,7 @@ class LuxCoreLightProps(bpy.types.PropertyGroup):
     ##############################################
     # Generic properties shared by all light types
     gain: FloatProperty(name="Gain", default=1, min=0, precision=4, description="Brightness multiplier")
+    exposure: FloatProperty(name="Exposure", default=0, soft_min=-10, soft_max=10, precision=2, description=EXPOSURE_DESCRIPTION)
     rgb_gain: FloatVectorProperty(name="Tint", default=(1, 1, 1), min=0, max=1, subtype="COLOR",
                                    description=RGB_GAIN_DESC)
     importance: FloatProperty(name="Importance", default=1, min=0, description=IMPORTANCE_DESCRIPTION)
@@ -129,8 +135,10 @@ class LuxCoreLightProps(bpy.types.PropertyGroup):
                            description="If radius is greater than 0, a sphere light is used")
 
     # point, mappoint, spot, laser
-    use_advanced: BoolProperty(name="Advanced", default=False,
-                               description = "Use power/efficacy values instead of gain to control emission")
+    light_units = [ ("artistic", "Artistic", "Artist friendly unit using Gain and Exposure"),  
+        ("power", "Power", "Radiant flux in Watts")
+    ]
+    light_unit: EnumProperty(name="Unit", items=light_units, default="artistic")
     power: FloatProperty(name="Power", default=100, min=0, description=POWER_DESCRIPTION, unit='POWER')
     efficacy: FloatProperty(name="Efficacy (lm/W)", default=17, min=0, description=EFFICACY_DESCRIPTION)
 

--- a/properties/light.py
+++ b/properties/light.py
@@ -58,7 +58,7 @@ TURBIDITY_DESC = (
 
 VIS_INDIRECT_BASE = (
     "Visibility for indirect {type} rays. "
-    "If disabled, this light will appear black in indirect bounces on {type} materials"
+    "If disabled, this light will appear black in indirect bounces on {type} materials."
 )
 VIS_INDIRECT_DIFFUSE_DESC = VIS_INDIRECT_BASE.format(type="diffuse") + " (e.g. matte)"
 VIS_INDIRECT_GLOSSY_DESC = VIS_INDIRECT_BASE.format(type="glossy") + " (e.g. glossy, roughglass, metal)"
@@ -165,7 +165,7 @@ class LuxCoreLightProps(bpy.types.PropertyGroup):
     # sky2, sun, infinite, constantinfinite, area
     visibility_indirect_diffuse: BoolProperty(name="Diffuse", default=True, description=VIS_INDIRECT_DIFFUSE_DESC)
     visibility_indirect_glossy: BoolProperty(name="Glossy", default=True, description=VIS_INDIRECT_GLOSSY_DESC)
-    visibility_indirect_specular: BoolProperty(name="Specular", default=True, description=VIS_INDIRECT_SPECULAR_DESC)
+    visibility_indirect_specular: BoolProperty(name="Specular", default=False, description=VIS_INDIRECT_SPECULAR_DESC)
 
     # sky2, infinite, constantinfinite
     # TODO description

--- a/properties/light.py
+++ b/properties/light.py
@@ -58,7 +58,7 @@ TURBIDITY_DESC = (
 
 VIS_INDIRECT_BASE = (
     "Visibility for indirect {type} rays. "
-    "If disabled, this light will appear black in indirect bounces on {type} materials."
+    "If disabled, this light will appear black in indirect bounces on {type} materials"
 )
 VIS_INDIRECT_DIFFUSE_DESC = VIS_INDIRECT_BASE.format(type="diffuse") + " (e.g. matte)"
 VIS_INDIRECT_GLOSSY_DESC = VIS_INDIRECT_BASE.format(type="glossy") + " (e.g. glossy, roughglass, metal)"
@@ -165,7 +165,7 @@ class LuxCoreLightProps(bpy.types.PropertyGroup):
     # sky2, sun, infinite, constantinfinite, area
     visibility_indirect_diffuse: BoolProperty(name="Diffuse", default=True, description=VIS_INDIRECT_DIFFUSE_DESC)
     visibility_indirect_glossy: BoolProperty(name="Glossy", default=True, description=VIS_INDIRECT_GLOSSY_DESC)
-    visibility_indirect_specular: BoolProperty(name="Specular", default=False, description=VIS_INDIRECT_SPECULAR_DESC)
+    visibility_indirect_specular: BoolProperty(name="Specular", default=True, description=VIS_INDIRECT_SPECULAR_DESC)
 
     # sky2, infinite, constantinfinite
     # TODO description

--- a/properties/world.py
+++ b/properties/world.py
@@ -18,6 +18,11 @@ USE_SUN_GAIN_FOR_SKY_DESC = (
     "(so you adjust both sun and sky gain at the same time)"
 )
 
+EXPOSURE_DESCRIPTION = (
+    "Power-of-2 step multiplier. "
+    "An EV step of 1 will double the brightness of the light"
+)
+
 SUN_DESC = (
     "If a sun is selected, the gain, turbidity and rotation from the sun are used for the sky"
 )
@@ -46,6 +51,7 @@ class LuxCoreWorldProps(bpy.types.PropertyGroup):
 
     # Generic properties shared by all background light types
     gain: FloatProperty(name="Gain", default=1, min=0, precision=4, description="Brightness multiplier")
+    exposure: FloatProperty(name="Exposure", default=0, soft_min=-10, soft_max=10, precision=2, description=EXPOSURE_DESCRIPTION )
     rgb_gain: FloatVectorProperty(name="Tint", default=(1, 1, 1), min=0, max=1, subtype="COLOR",
                                    description=RGB_GAIN_DESC)
     importance: FloatProperty(name="Importance", default=1, min=0, description=IMPORTANCE_DESCRIPTION)

--- a/ui/light.py
+++ b/ui/light.py
@@ -204,21 +204,17 @@ class LUXCORE_LIGHT_PT_visibility(DataButtonsPanel, Panel):
 
         # These settings only work with PATH and TILEPATH, not with BIDIR
         enabled = context.scene.luxcore.config.engine == "PATH"
-        
-        if not enabled:
-            layout.label(text="Only supported by Path engines (not by Bidir)", icon=icons.INFO)
 
         col = layout.column()
         col.enabled = enabled
         col.label(text="Visibility for indirect light rays:")
-        col = col.column()        
+        col = layout.column()        
         col.prop(light.luxcore, "visibility_indirect_diffuse")
         col.prop(light.luxcore, "visibility_indirect_glossy")
         col.prop(light.luxcore, "visibility_indirect_specular")
-        
-        if light.luxcore.visibility_indirect_specular:
-            col.label(text="Indirect Specular rays can create unwanted fireflies", icon=icons.WARNING)
 
+        if not enabled:
+            layout.label(text="Only supported by Path engines (not by Bidir)", icon=icons.INFO)
 
 
 class LUXCORE_LIGHT_PT_spot(DataButtonsPanel, Panel):

--- a/ui/light.py
+++ b/ui/light.py
@@ -204,17 +204,21 @@ class LUXCORE_LIGHT_PT_visibility(DataButtonsPanel, Panel):
 
         # These settings only work with PATH and TILEPATH, not with BIDIR
         enabled = context.scene.luxcore.config.engine == "PATH"
+        
+        if not enabled:
+            layout.label(text="Only supported by Path engines (not by Bidir)", icon=icons.INFO)
 
         col = layout.column()
         col.enabled = enabled
         col.label(text="Visibility for indirect light rays:")
-        col = layout.column()        
+        col = col.column()        
         col.prop(light.luxcore, "visibility_indirect_diffuse")
         col.prop(light.luxcore, "visibility_indirect_glossy")
         col.prop(light.luxcore, "visibility_indirect_specular")
+        
+        if light.luxcore.visibility_indirect_specular:
+            col.label(text="Indirect Specular rays can create unwanted fireflies", icon=icons.WARNING)
 
-        if not enabled:
-            layout.label(text="Only supported by Path engines (not by Bidir)", icon=icons.INFO)
 
 
 class LUXCORE_LIGHT_PT_spot(DataButtonsPanel, Panel):

--- a/ui/light.py
+++ b/ui/light.py
@@ -57,7 +57,7 @@ class LUXCORE_LIGHT_PT_context_light(DataButtonsPanel, Panel):
         layout.use_property_decorate = False
 
         if light.type in {"POINT", "SPOT", "AREA"}:
-            layout.prop(light.luxcore, "use_advanced")
+            layout.prop(light.luxcore, "light_unit")
 
         if light.type == "AREA" and light.luxcore.node_tree:
             layout.label(text="Light color is defined by emission node", icon=icons.INFO)
@@ -65,12 +65,14 @@ class LUXCORE_LIGHT_PT_context_light(DataButtonsPanel, Panel):
             if not (light.type == "SUN" and light.luxcore.light_type == "sun"):
                 layout.prop(light.luxcore, "rgb_gain", text="Color")
 
-        if light.luxcore.use_advanced and light.type in {"POINT", "SPOT", "AREA"}:
+        if light.luxcore.light_unit == "power" and light.type in {"POINT", "SPOT", "AREA"}:
             col = layout.column(align=True)
             col.prop(light.luxcore, "power")
             col.prop(light.luxcore, "efficacy")
         else:
-            layout.prop(light.luxcore, "gain")
+            col = layout.column(align=True)
+            col.prop(light.luxcore, "gain")
+            col.prop(light.luxcore, "exposure", slider=True)
 
         col = layout.column(align=True)
         op = col.operator("luxcore.switch_space_data_context", text="Show Light Groups")

--- a/ui/world.py
+++ b/ui/world.py
@@ -38,8 +38,10 @@ class LUXCORE_PT_context_world(WorldButtonsPanel, Panel):
             col = layout.column(align=True)
             if is_sky and has_sun and world.luxcore.use_sun_gain_for_sky:
                 col.prop(world.luxcore.sun.data.luxcore, "gain")
+                col.prop(world.luxcore.sun.data.luxcore, "exposure", slider=True)
             else:
                 col.prop(world.luxcore, "gain")
+                col.prop(world.luxcore, "exposure", slider=True)
 
             if is_sky and has_sun:
                 col.prop(world.luxcore, "use_sun_gain_for_sky")


### PR DESCRIPTION
- Replace use_advanced with light_unit in preparation for more unit support in the future.
- Adds Artistic and Power units to local lights.
- Adds Exposure setting to Artistic light unit (similar to Arnold and Renderman) for world, sun and local lights.
- Also added Units and Exposure for Emission node.

NOTE: Changing the Exposure value on the emission node doesn't update the viewport render properly. It requires a Gain change or viewport restart to be taken into account.