### PR TITLE
Adding Normalize by Color Luminance for Power unit.

### DIFF
--- a/export/light.py
+++ b/export/light.py
@@ -97,6 +97,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.light_unit == "power":
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
+            definitions["normalizebycolor"] = light.luxcore.normalizebycolor
 
             if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
                 definitions["gain"] = [0, 0, 0]
@@ -106,6 +107,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
+            definitions["normalizebycolor"] = False
 
         # Position is set by transformation property
         definitions["position"] = [0, 0, 0]
@@ -175,6 +177,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         if light.luxcore.light_unit == "power":
             definitions["efficency"] = light.luxcore.efficacy
             definitions["power"] = light.luxcore.power
+            definitions["normalizebycolor"] = light.luxcore.normalizebycolor
 
             if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
                 definitions["gain"] = [0, 0, 0]
@@ -184,6 +187,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
         else:
             definitions["efficency"] = 0.0
             definitions["power"] = 0.0
+            definitions["normalizebycolor"] = False
 
         # Position and direction are set by transformation property
         definitions["position"] = [0, 0, 0]
@@ -204,6 +208,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
             if light.luxcore.light_unit == "power":
                 definitions["efficency"] = light.luxcore.efficacy
                 definitions["power"] = light.luxcore.power
+                definitions["normalizebycolor"] = light.luxcore.normalizebycolor
 
                 if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
                     definitions["gain"] = [0, 0, 0]
@@ -213,6 +218,7 @@ def convert_luxcore_settings(exporter, obj, obj_key, depsgraph, luxcore_scene, t
             else:
                 definitions["efficency"] = 0.0
                 definitions["power"] = 0.0
+                definitions["normalizebycolor"] = False
 
             # Position and direction are set by transformation property
             definitions["position"] = [0, 0, 0]
@@ -381,6 +387,7 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
         "emission.gain": apply_exposure(gain, light.luxcore.exposure),
         "emission.power": 0.0,
         "emission.efficency": 0.0,
+        "emission.normalizebycolor": False,
         "emission.theta": math.degrees(light.luxcore.spread_angle),
         "emission.id": scene.luxcore.lightgroups.get_id_by_name(light.luxcore.lightgroup),
         "emission.importance": importance,
@@ -395,6 +402,7 @@ def _convert_area_light(obj, scene, is_viewport_render, exporter, depsgraph, lux
     if light.luxcore.light_unit == "power":
         mat_definitions["emission.power"] = light.luxcore.power
         mat_definitions["emission.efficency"] = light.luxcore.efficacy
+        mat_definitions["emission.normalizebycolor"] = light.luxcore.normalizebycolor
 
         if light.luxcore.efficacy == 0 or light.luxcore.power == 0:
             mat_definitions["emission.gain"] = [0, 0, 0]

--- a/properties/light.py
+++ b/properties/light.py
@@ -24,6 +24,11 @@ POWER_DESCRIPTION = (
     "this feature and uses only the light gain"
 )
 
+NORMALIZEBYCOLOR_DESCRIPTION = (
+    "Normalize intensity by the Color Luminance; Radiometric units like Power should not be "
+    "normalized, while Photometric units like Lumen, Candela, Lux should."
+)
+
 EXPOSURE_DESCRIPTION = (
     "Power-of-2 step multiplier. "
     "An EV step of 1 will double the brightness of the light"
@@ -141,6 +146,7 @@ class LuxCoreLightProps(bpy.types.PropertyGroup):
     light_unit: EnumProperty(name="Unit", items=light_units, default="artistic")
     power: FloatProperty(name="Power", default=100, min=0, description=POWER_DESCRIPTION, unit='POWER')
     efficacy: FloatProperty(name="Efficacy (lm/W)", default=17, min=0, description=EFFICACY_DESCRIPTION)
+    normalizebycolor: BoolProperty(name="Normalize by Color Luminance", default=False, description=NORMALIZEBYCOLOR_DESCRIPTION)
 
     # mappoint
     ies: PointerProperty(type=LuxCoreIESProps)

--- a/ui/light.py
+++ b/ui/light.py
@@ -69,6 +69,7 @@ class LUXCORE_LIGHT_PT_context_light(DataButtonsPanel, Panel):
             col = layout.column(align=True)
             col.prop(light.luxcore, "power")
             col.prop(light.luxcore, "efficacy")
+            layout.prop(light.luxcore, "normalizebycolor")
         else:
             col = layout.column(align=True)
             col.prop(light.luxcore, "gain")


### PR DESCRIPTION
Set to False by default to mimic previous behavior and Cycles. Power is a radiometric unit and should not be normalized.

WARNING: Point, Laser, Area and Emissive materials work fine, but Spotlights export with normalizeycolor = True no matter what is set in the UI. Can't find the cause, please help me with that.