### PR TITLE
Pop OIDN to v1.2.1, Use shutil.which to locate `odinDenoise` binary.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@ import bpy
 import addon_utils
 import platform
 import os
+from shutil import which
 
 
 _, luxblend_is_enabled = addon_utils.check("luxrender")
@@ -43,7 +44,11 @@ if platform.system() in {"Linux", "Darwin"}:
     
     # Make sure denoiser is executable
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    denoiser_path = os.path.join(current_dir, "bin", "denoise")
+    denoiser_path = which(
+        'denoise',
+        mode=os.F_OK,
+        path=os.path.join(current_dir, "bin")+os.pathsep+os.environ["PATH"]
+    )
     if not os.access(denoiser_path, os.X_OK):
         print("Making LuxCore denoiser executable")
         os.chmod(denoiser_path, 0o755)

--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ if platform.system() in {"Linux", "Darwin"}:
     # Make sure denoiser is executable
     current_dir = os.path.dirname(os.path.realpath(__file__))
     denoiser_path = which(
-        'denoise',
+        'oidnDenoise',
         mode=os.F_OK,
         path=os.path.join(current_dir, "bin")+os.pathsep+os.environ["PATH"]
     )

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -6,5 +6,5 @@ pyluxcoretools.zip
 pyluxcoretool.exe
 luxcoreui
 luxcoreui.exe
-denoise
-denoise.exe
+oidnDenoise
+oidnDenoise.exe

--- a/bin/get_binaries.py
+++ b/bin/get_binaries.py
@@ -15,12 +15,12 @@ WINDOWS_FILES = [
     "embree3.dll", "tbb.dll", "tbbmalloc.dll",
     "OpenImageIO.dll", "pyluxcore.pyd", "luxcoreui.exe",
     "pyluxcoretool.exe", "pyluxcoretools.zip",
-    "OpenImageDenoise.dll", "denoise.exe", 
+    "OpenImageDenoise.dll", "oidnDenoise.exe", 
 ]
 
 MAC_FILES = [
-    "libembree3.3.dylib", "libomp.dylib", "libOpenImageDenoise.1.2.0.dylib", "libOpenImageIO.1.8.dylib", "libtbb.dylib",
-    "libtbbmalloc.dylib", "libtiff.5.dylib", "pyluxcore.so", "pyluxcoretools.zip", "denoise"
+    "libembree3.3.dylib", "libomp.dylib", "libOpenImageDenoise.1.2.1.dylib", "libOpenImageIO.1.8.dylib", "libtbb.dylib",
+    "libtbbmalloc.dylib", "libtiff.5.dylib", "pyluxcore.so", "pyluxcoretools.zip", "oidnDenoise"
 ]
 
 

--- a/draw/viewport.py
+++ b/draw/viewport.py
@@ -8,6 +8,7 @@ import tempfile
 from ..bin import pyluxcore
 from .. import utils
 from ..utils import pfm
+from shutil import which
 
 NULL = 0
 
@@ -73,9 +74,10 @@ class FrameBuffer(object):
         self._normal_file_path = self._make_denoiser_filepath("normal")
         self._denoised_file_path = self._make_denoiser_filepath("denoised")
         current_dir = os.path.dirname(os.path.realpath(__file__))
-        self._denoiser_path = os.path.join(os.path.dirname(current_dir), "bin", "denoise")
-        if platform.system() == "Windows":
-            self._denoiser_path += ".exe"
+        self._denoiser_path = which(
+            "denoise",
+            path=os.path.join(current_dir, "bin")+os.pathsep+os.environ["PATH"]
+        )
         self._denoiser_process = None
         self.denoiser_result_cached = False
 

--- a/draw/viewport.py
+++ b/draw/viewport.py
@@ -75,7 +75,7 @@ class FrameBuffer(object):
         self._denoised_file_path = self._make_denoiser_filepath("denoised")
         current_dir = os.path.dirname(os.path.realpath(__file__))
         self._denoiser_path = which(
-            "denoise",
+            "oidnDenoise",
             path=os.path.join(current_dir, "bin")+os.pathsep+os.environ["PATH"]
         )
         self._denoiser_process = None

--- a/release/package_releases.py
+++ b/release/package_releases.py
@@ -53,16 +53,16 @@ WINDOWS_FILES = [
     "embree3.dll", "tbb.dll", "tbbmalloc.dll",
     "OpenImageIO.dll", "pyluxcore.pyd",
     "pyluxcoretool.exe", "pyluxcoretools.zip",
-    "OpenImageDenoise.dll", "denoise.exe",
+    "OpenImageDenoise.dll", "oidnDenoise.exe",
     "nvrtc64_101_0.dll", "nvrtc-builtins64_101.dll",
 ]
 
 MAC_FILES = [
     "libembree3.3.dylib", "libomp.dylib", 
-    "libOpenImageDenoise.1.2.0.dylib", "libOpenImageIO.1.8.dylib",
+    "libOpenImageDenoise.1.2.1.dylib", "libOpenImageIO.1.8.dylib",
     "libcuda.dylib", "libnvrtc.dylib",
     "libtbb.dylib", "libtbbmalloc.dylib", "libtiff.5.dylib", 
-    "pyluxcore.so", "pyluxcoretools.zip", "denoise"
+    "pyluxcore.so", "pyluxcoretools.zip", "oidnDenoise"
 ]
 
 #OIDN_WIN = "oidn-windows.zip"
@@ -70,9 +70,9 @@ OIDN_LINUX = "oidn-linux.tar.gz"
 #OIDN_MAC = "oidn-macos.tar.gz"
 
 OIDN_urls = {
-    #OIDN_WIN: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.0.0/oidn-1.0.0.x64.vc14.windows.zip",
-    OIDN_LINUX: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.0.0/oidn-1.0.0.x86_64.linux.tar.gz",
-    #OIDN_MAC: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.0.0/oidn-1.0.0.x86_64.macos.tar.gz",
+    #OIDN_WIN: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.2.1/oidn-1.2.1.x64.vc14.windows.zip",
+    OIDN_LINUX: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.2.1/oidn-1.2.1.x86_64.linux.tar.gz",
+    #OIDN_MAC: "https://github.com/OpenImageDenoise/oidn/releases/download/v1.2.1/oidn-1.2.1.x86_64.macos.tar.gz",
 }
 
 
@@ -342,11 +342,11 @@ def main():
         destination = os.path.join(script_dir, name, "BlendLuxCore", "bin")
 
         #if "win64" in suffix:
-        #    extract_files_from_archive(OIDN_WIN, ["denoise.exe"], destination)
+        #    extract_files_from_archive(OIDN_WIN, ["oidnDenoise.exe"], destination)
         if "linux64" in suffix:
-            extract_files_from_archive(OIDN_LINUX, ["denoise"], destination)
+            extract_files_from_archive(OIDN_LINUX, ["oidnDenoise"], destination)
         #elif "mac64" in suffix:
-        #    extract_files_from_archive(OIDN_MAC, ["denoise"], destination)
+        #    extract_files_from_archive(OIDN_MAC, ["oidnDenoise"], destination)
 
     # Linux archives are tar.bz2
     linux_suffixes = [suffix for suffix in suffixes if "-linux" in suffix]


### PR DESCRIPTION
Use `which()` to locate `oidnDenoise` binary, allowing use of system wide `openimagedenoise` e.g. on Linux.
Priority to local ( `cwd\bin` ) path.
Tested on:
- [x] Linux: {blender:2.83.1, openimagedenoise:1.2.0, luxcorerender-git:2.4.beta1.r1.g35eca7c19}
- [ ] Windows
- [ ] Mac
