### PR TITLE
Fix imagepipeline.transparent_film viewport background

### DIFF
--- a/properties/imagepipeline.py
+++ b/properties/imagepipeline.py
@@ -213,7 +213,11 @@ class LuxCoreImagepipeline(PropertyGroup):
     Used (and initialized) in properties/camera.py
     The UI elements are located in ui/camera.py
     """
-    transparent_film: BoolProperty(name="Transparent Film", default=False,
+    def update_transparent_film(self, context):
+        if context.object is context.scene.camera:
+            context.scene.render.film_transparent = self.transparent_film
+
+    transparent_film: BoolProperty(name="Transparent Film", default=False, update=update_transparent_film,
                                     description="Make the world background transparent")
 
     tonemapper: PointerProperty(type=LuxCoreImagepipelineTonemapper)


### PR DESCRIPTION
Show the same Cycles/EEVEE transparent checkerboard viewport background for the scene camera.

![film_transparent_patch](https://user-images.githubusercontent.com/639472/102696106-2adc3180-422c-11eb-95d4-dd1ac38d02b2.jpg)

