### PR TITLE
Allow the user to select a separate `halt_spp` for eye and light path

### DIFF
--- a/export/halt.py
+++ b/export/halt.py
@@ -10,12 +10,14 @@ def convert(scene):
 
     halt = utils.get_halt_conditions(scene)
     config = scene.luxcore.config
+    using_hybridbackforward = utils.using_hybridbackforward(scene)
+    using_only_lighttracing = config.using_only_lighttracing()
 
     if halt.enable:
         halt_time = halt.time if halt.use_time else 0
         halt_spp_eye = halt.samples if halt.use_samples else 0
         halt_spp_light = halt.light_samples if (halt.use_light_samples
-            and not config.using_only_lighttracing()) else 0
+            and using_hybridbackforward and not using_only_lighttracing) else 0
 
         if halt.use_noise_thresh:
             if halt.noise_thresh == 0:
@@ -41,7 +43,7 @@ def convert(scene):
         halt_spp_eye = max(halt_spp_eye, 2 * aa**2)
 
     # Swap halt condition if no eye samples are rendered at all
-    if config.using_only_lighttracing():
+    if using_only_lighttracing:
         halt_spp_light = halt_spp_eye
         halt_spp_eye = 0
 

--- a/properties/halt.py
+++ b/properties/halt.py
@@ -1,9 +1,28 @@
 import bpy
 from bpy.props import IntProperty, BoolProperty
 
+USE_SAMPLES_DESC = (
+    "The rendering will stop when the number of samples reaches "
+    "the specified value"
+)
+
+SAMPLES_DESC = (
+    "At least this many samples will be rendered before stopping"
+)
+
+USE_LIGHT_PATH_SAMPLES_DESC = (
+    "The rendering will stop when the number of light path samples reaches "
+    "the specified value"
+)
+
+LIGHT_PATH_SAMPLES_DESC = (
+    "At least this many light path samples will be rendered before stopping"
+)
+
 USE_NOISE_THRESH_DESC = (
     "The rendering will stop when the noise in the image falls "
-    "below the specified threshold")
+    "below the specified threshold"
+)
 
 NOISE_THRESH_DESC = (
     "Value between 0 and 255. If the noise falls below this value, the rendering is stopped. "
@@ -27,8 +46,15 @@ class LuxCoreHaltConditions(bpy.types.PropertyGroup):
     use_time: BoolProperty(name="Use Time", default=False)
     time: IntProperty(name="Time (s)", default=600, min=1)
 
-    use_samples: BoolProperty(name="Use Samples", default=False)
-    samples: IntProperty(name="Samples", default=500, min=1)
+    use_samples: BoolProperty(name="Use Samples", default=False,
+                               description=USE_SAMPLES_DESC)
+    samples: IntProperty(name="Samples", default=500, min=1,
+                          description=SAMPLES_DESC)
+
+    use_light_samples: BoolProperty(name="Use Light Path Samples", default=False,
+                                     description=USE_LIGHT_PATH_SAMPLES_DESC)
+    light_samples: IntProperty(name="Light Path Samples", default=100, min=1,
+                                description=LIGHT_PATH_SAMPLES_DESC)
 
     # Noise threshold
     use_noise_thresh: BoolProperty(name="Use Noise Threshold", default=False,

--- a/ui/render/halt.py
+++ b/ui/render/halt.py
@@ -1,6 +1,7 @@
 from bl_ui.properties_render import RenderButtonsPanel
 from bl_ui.properties_view_layer import ViewLayerButtonsPanel
 from bpy.types import Panel
+from ... import utils
 from ...utils import ui as utils_ui
 from .. import icons
 from .sampling import calc_samples_per_pass
@@ -27,7 +28,10 @@ def draw(layout, context, halt):
 
     config = context.scene.luxcore.config
     denoiser = context.scene.luxcore.denoiser
-    
+
+    using_hybridbackforward = utils.using_hybridbackforward(context.scene)
+    using_only_lighttracing = config.using_only_lighttracing()
+
     if halt.use_samples:
         samples_per_pass = calc_samples_per_pass(config)
         
@@ -60,7 +64,7 @@ def draw(layout, context, halt):
             if halt.samples < min_samples:
                 layout.label(text="Use at least %d samples!" % min_samples, icon=icons.WARNING)
 
-    if config.path.hybridbackforward_enable and not config.using_only_lighttracing():
+    if using_hybridbackforward and not using_only_lighttracing:
         layout.prop(halt, "use_light_samples")
         col = layout.column(align=True)
         col.active = halt.use_light_samples
@@ -115,6 +119,9 @@ class LUXCORE_RENDER_PT_halt_conditions(Panel, RenderButtonsPanel):
                                 text="Show", icon="RENDERLAYERS")
             op.target = "VIEW_LAYER"
 
+            using_hybridbackforward = utils.using_hybridbackforward(context.scene)
+            using_only_lighttracing = config.using_only_lighttracing()
+
             for layer in overriding_layers:
                 halt = layer.luxcore.halt
                 conditions = []
@@ -123,8 +130,8 @@ class LUXCORE_RENDER_PT_halt_conditions(Panel, RenderButtonsPanel):
                     conditions.append("Time (%ds)" % halt.time)
                 if halt.use_samples:
                     conditions.append("Samples (%d)" % halt.samples)
-                if (halt.use_light_samples and config.path.hybridbackforward_enable
-                        and not config.using_only_lighttracing()):
+                if (halt.use_light_samples and using_hybridbackforward
+                        and not using_only_lighttracing):
                     conditions.append("Light Path Samples (%d)" % halt.light_samples)
                 if halt.use_noise_thresh:
                     conditions.append("Noise (%d)" % halt.noise_thresh)

--- a/ui/render/halt.py
+++ b/ui/render/halt.py
@@ -60,8 +60,14 @@ def draw(layout, context, halt):
             if halt.samples < min_samples:
                 layout.label(text="Use at least %d samples!" % min_samples, icon=icons.WARNING)
 
+    if config.path.hybridbackforward_enable and not config.using_only_lighttracing():
+        layout.prop(halt, "use_light_samples")
+        col = layout.column(align=True)
+        col.active = halt.use_light_samples
+        col.prop(halt, "light_samples")
+
+    layout.prop(halt, "use_noise_thresh")
     col = layout.column(align=True)
-    col.prop(halt, "use_noise_thresh")
     if halt.use_noise_thresh:
         col.prop(halt, "noise_thresh")
         col.prop(halt, "noise_thresh_warmup")
@@ -91,6 +97,7 @@ class LUXCORE_RENDER_PT_halt_conditions(Panel, RenderButtonsPanel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
+        config = context.scene.luxcore.config
         halt = context.scene.luxcore.halt
         draw(layout, context, halt)
 
@@ -116,6 +123,9 @@ class LUXCORE_RENDER_PT_halt_conditions(Panel, RenderButtonsPanel):
                     conditions.append("Time (%ds)" % halt.time)
                 if halt.use_samples:
                     conditions.append("Samples (%d)" % halt.samples)
+                if (halt.use_light_samples and config.path.hybridbackforward_enable
+                        and not config.using_only_lighttracing()):
+                    conditions.append("Light Path Samples (%d)" % halt.light_samples)
                 if halt.use_noise_thresh:
                     conditions.append("Noise (%d)" % halt.noise_thresh)
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -491,10 +491,14 @@ def using_bidir_in_viewport(scene):
     return scene.luxcore.config.engine == "BIDIR" and scene.luxcore.viewport.use_bidir
 
 
-def using_hybridbackforward_in_viewport(scene):
+def using_hybridbackforward(scene):
     config = scene.luxcore.config
     return (config.engine == "PATH" and not config.use_tiles
-            and config.path.hybridbackforward_enable and scene.luxcore.viewport.add_light_tracing)
+            and config.path.hybridbackforward_enable)
+
+
+def using_hybridbackforward_in_viewport(scene):
+    return using_hybridbackforward(scene) and scene.luxcore.viewport.add_light_tracing
 
 
 def using_photongi_debug_mode(is_viewport_render, scene):


### PR DESCRIPTION
Added an extra Halt Condition (conditionally, only if Light Tracing is enabled) to specify number of samples for light paths:

![image](https://user-images.githubusercontent.com/5019658/107152959-1eb85900-69bf-11eb-82b0-87e7eb41f42d.png)

This is useful for guaranteeing that a minimum number of Light Tracing paths is reached; especially good for constant quality of [animations](https://www.youtube.com/watch?v=g0PkMCnD8U4) when your GPU is much faster than your CPU.

It is independent of the existing Use Samples setting, and works together with it in the intended manner. If both settings are selected, then the render will only terminate once both limits are reached. If either value is not selected, `0` will be used for it, and only the other limit will apply.

I've also updated the progress indicator so it progresses with the slowest of the two limits, if they are both enabled.

![image](https://user-images.githubusercontent.com/5019658/107153158-1ad90680-69c0-11eb-93b6-762d4ffcb3c3.png)
