### PR TITLE
Blender 3 0

### DIFF
--- a/handlers/lol/timer.py
+++ b/handlers/lol/timer.py
@@ -46,16 +46,15 @@ def timer_update():
 
         if tcom.finished:
             thread.stop()
-            if not tcom.passargs['thumbnail']:
-                for a in assets:
-                    if a['hash'] == asset['hash']:
-                        a['downloaded'] = 100.0
-                        break
-                for d in tcom.passargs['downloaders']:
-                    if tcom.passargs['asset type'] == 'MATERIAL':
-                        utils.append_material(bpy.context, asset, d['target_object'], d['target_slot'])
-                    else:
-                        utils.link_asset(bpy.context, asset, d['location'], d['rotation'])
+            for a in assets:
+                if a['hash'] == asset['hash']:
+                    a['downloaded'] = 100.0
+                    break
+            for d in tcom.passargs['downloaders']:
+                if tcom.passargs['asset type'] == 'MATERIAL':
+                    utils.append_material(bpy.context, asset, d['target_object'], d['target_slot'])
+                else:
+                    utils.link_asset(bpy.context, asset, d['location'], d['rotation'])
 
             utils.download_threads.remove(threaddata)
 
@@ -71,11 +70,10 @@ def timer_update():
                 running = running + 1
                 thread.start()
 
-        if not tcom.passargs['thumbnail']:
-            for a in assets:
-                if a['hash'] == asset['hash']:
-                    a['downloaded'] = tcom.progress
-                    break
+        for a in assets:
+            if a['hash'] == asset['hash']:
+                a['downloaded'] = tcom.progress
+                break
 
         for area in bpy.data.window_managers['WinMan'].windows[0].screen.areas:
             if area.type == 'VIEW_3D':

--- a/nodes/nodeitems.py
+++ b/nodes/nodeitems.py
@@ -22,4 +22,4 @@ class NodeItemMultiImageImport(NodeItemCustom):
     def __init__(self, poll=None, draw=None):
         if draw is None:
             draw = self.draw_operator
-        super().__init__(poll, draw)
+        super().__init__(poll=poll, draw=draw)

--- a/operators/lol/assetbar.py
+++ b/operators/lol/assetbar.py
@@ -64,9 +64,6 @@ def draw_callback_2d_progress(self, context):
     for threaddata in utils.download_threads:
         tcom = threaddata[2]
 
-        if tcom.passargs['thumbnail']:
-            continue
-
         asset_data = threaddata[1]
 
         img = utils.get_thumbnail('thumbnail_notready.jpg')
@@ -85,8 +82,6 @@ def draw_callback_2d_progress(self, context):
 def draw_callback_3d_progress(self, context):
     for threaddata in utils.download_threads:
         tcom = threaddata[2]
-        if tcom.passargs['thumbnail']:
-            continue
 
         asset_data = threaddata[1]
         if tcom.passargs['asset type'] == 'MODEL':

--- a/operators/lol/assetbar.py
+++ b/operators/lol/assetbar.py
@@ -69,9 +69,9 @@ def draw_callback_2d_progress(self, context):
 
         asset_data = threaddata[1]
 
-        img = asset_data['thumbnail']
-        if img is None:
-            img = utils.get_thumbnail('thumbnail_notready.jpg')
+        img = utils.get_thumbnail('thumbnail_notready.jpg')
+        if 'thumbnail' in asset_data.keys() and asset_data['thumbnail'] != None and asset_data['thumbnail'].size[0] != 0:
+            img = asset_data['thumbnail']
 
         if tcom.passargs.get('downloaders'):
             for d in tcom.passargs['downloaders']:
@@ -186,10 +186,11 @@ def draw_callback_2d_search(self, context):
                             assetbar_props.margin + ui_props.thumb_size) + assetbar_props.margin + assetbar_props.drawoffset
 
                     index = a + ui_props.scrolloffset + b * assetbar_props.wcount
-                    img = assets[index]['thumbnail']
 
-                    if img is None or img.size[0] == 0:
-                        img = utils.get_thumbnail('thumbnail_notready.jpg')
+                    img = utils.get_thumbnail('thumbnail_notready.jpg')
+                    asset = assets[index]
+                    if 'thumbnail' in asset.keys() and asset['thumbnail'] != None and asset['thumbnail'].size[0] != 0:
+                        img = asset['thumbnail']
 
                     w = int(ui_props.thumb_size * img.size[0] / max(img.size[0], img.size[1]))
                     h = int(ui_props.thumb_size * img.size[1] / max(img.size[0], img.size[1]))

--- a/ui/lol/panel.py
+++ b/ui/lol/panel.py
@@ -228,9 +228,6 @@ class VIEW3D_PT_LUXCORE_ONLINE_LIBRARY_DOWNLOADS(Panel):
 
         for idx, threaddata in enumerate(utils.download_threads):
            tcom = threaddata[2]
-           if tcom.passargs['thumbnail']:
-               continue
-
            asset_data = threaddata[1]
 
            row = layout.row()

--- a/utils/lol/utils.py
+++ b/utils/lol/utils.py
@@ -572,24 +572,6 @@ def get_scene_id():
     bpy.context.scene['uuid'] = bpy.context.scene.get('uuid', str(uuid.uuid4()))
     return bpy.context.scene['uuid']
 
-
-def download_thumbnail(self, context, asset):
-    ui_props = context.scene.luxcoreOL.ui
-
-    tcom = is_downloading(asset)
-    if tcom is None:
-        tcom = ThreadCom()
-        tcom.passargs['thumbnail'] = True
-        tcom.passargs['asset type'] = ui_props.asset_type
-
-        downloadthread = Downloader(asset, tcom)
-
-        download_threads.append([downloadthread, asset, tcom])
-        bpy.app.timers.register(timer_update)
-
-    return True
-
-
 def get_thumbnail(imagename):
     # Prepend a dot so the image is hidden to users, e.g. in Blender's search
     imagename_blender = '.' + imagename

--- a/utils/lol/utils.py
+++ b/utils/lol/utils.py
@@ -92,6 +92,7 @@ def load_patreon_assets(context):
                 if os.path.exists(filepath):
                     asset['locked'] = False
     else:
+        import urllib.request
         urlstr = LOL_HOST_URL + "/" + LOL_VERSION + "/assets_model_blendermarket.json"
         with urllib.request.urlopen(urlstr, timeout=60) as request:
             import json

--- a/utils/lol/utils.py
+++ b/utils/lol/utils.py
@@ -30,7 +30,7 @@
 
 import bpy
 import uuid
-from os.path import basename, dirname, join, isfile, splitext
+from os.path import basename, dirname, join, isfile, splitext, exists, getsize
 import hashlib
 import tempfile
 import os
@@ -40,6 +40,7 @@ import threading
 from threading import _MainThread, Thread, Lock
 from ...handlers.lol.timer import timer_update
 from ...utils import get_addon_preferences, compatibility
+
 
 LOL_HOST_URL = "https://luxcorerender.org/lol"
 LOL_VERSION = "v2.5"
@@ -115,6 +116,7 @@ def load_patreon_assets(context):
 
 
 def download_table_of_contents(context):
+    global bg_threads
     scene = context.scene
     ui_props = context.scene.luxcoreOL.ui
     name = basename(dirname(dirname(dirname(__file__))))
@@ -203,6 +205,7 @@ def download_table_of_contents(context):
 
         ui_props.ToC_loaded = True
         init_categories(context)
+
         bg_task = Thread(target=check_cache, args=(context, ))
         bg_threads.append(["check_cache", bg_task])
         bg_task.start()
@@ -214,7 +217,6 @@ def download_table_of_contents(context):
     except urllib.error.URLError as error:
         print("URL error: Could not download table of contents")
         print(error)
-
         return False
 
     finally:
@@ -258,8 +260,7 @@ def init_categories(context):
 
 def check_cache(args):
     (context) = args
-    name = basename(dirname(dirname(dirname(__file__))))
-    user_preferences = context.preferences.addons[name].preferences
+    global bg_threads
     global stop_check_cache
 
     user_preferences = get_addon_preferences(context)
@@ -274,15 +275,6 @@ def check_cache(args):
         if os.path.exists(filepath):
             if calc_hash(filepath) == asset["hash"]:
                 asset['downloaded'] = 100.0
-
-    # assets = scene.luxcoreOL.scene['assets']
-    # for asset in assets:
-    #     filename = asset["url"]
-    #     filepath = join(user_preferences.global_dir, "scene", splitext(filename)[0] + '.blend')
-    #
-    #     if os.path.exists(filepath):
-    #         if calc_hash(filepath) == asset["hash"]:
-    #             asset['downloaded'] = 100.0
 
     assets = scene.luxcoreOL.material['assets']
     for asset in assets:
@@ -317,8 +309,6 @@ def calc_hash(filename):
 def is_downloading(asset):
     global download_threads
     for thread_data in download_threads:
-        if thread_data[2].passargs['thumbnail']:
-            continue
         if asset['hash'] == thread_data[1]['hash']:
             return thread_data[2]
     return None
@@ -334,7 +324,6 @@ def download_file(asset_type, asset, location, rotation, target_object, target_s
     if tcom is None:
         tcom = ThreadCom()
         tcom.passargs['downloaders'] = [downloader]
-        tcom.passargs['thumbnail'] = False
         tcom.passargs['asset type'] = asset_type
         asset_data = asset.to_dict()
 
@@ -366,107 +355,53 @@ class Downloader(threading.Thread):
     def run(self):
         import urllib.request
         user_preferences = get_addon_preferences(bpy.context)
-
-        # print("Download Thread running")
         tcom = self.tcom
 
-        if tcom.passargs['thumbnail']:
-            # Thumbnail  download
-            if tcom.passargs['asset type'] == 'MATERIAL':
-                imagename = self.asset['name'].replace(" ", "_") + '.jpg'
-            else:
-                imagename = splitext(self.asset['url'])[0] + '.jpg'
+        filename = self.asset["url"]
 
-            thumbnailpath = os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower(), 'preview',
-                                         'full', imagename)
-            url = LOL_HOST_URL + "/" + tcom.passargs['asset type'].lower() + "/preview/" + imagename
+        with tempfile.TemporaryDirectory() as temp_dir_path:
+            temp_zip_path = os.path.join(temp_dir_path, filename)
+            url = LOL_HOST_URL + "/" + tcom.passargs['asset type'].lower() + "/" + filename
             try:
-                with urllib.request.urlopen(url, timeout=60) as url_handle, open(thumbnailpath, "wb") as file_handle:
-                    file_handle.write(url_handle.read())
+                print("Downloading:", url)
+                with urllib.request.urlopen(url, timeout=60) as url_handle, \
+                        open(temp_zip_path, "wb") as file_handle:
+                    total_length = url_handle.headers.get('Content-Length')
+                    tcom.file_size = int(total_length)
 
-                thumbnailpath_low = os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower(),
-                                             'preview', imagename)
+                    dl = 0
+                    data = url_handle.read(8192)
+                    file_handle.write(data)
+                    while len(data) == 8192:
+                        data = url_handle.read(8192)
+                        dl += len(data)
+                        tcom.downloaded = dl
+                        tcom.progress = int(100 * tcom.downloaded / tcom.file_size)
 
-                from shutil import copyfile
-                copyfile(thumbnailpath, thumbnailpath_low)
+                        # Stop download if Blender is closed
+                        for thread in threading.enumerate():
+                            if isinstance(thread, _MainThread):
+                                if not thread.is_alive():
+                                    self.stop()
 
-                img = bpy.data.images.load(thumbnailpath_low)
-                img.scale(128, 128)
-                img.save()
-                bpy.data.images.remove(img)
+                        file_handle.write(data)
+                        if self.stopped():
+                            url_handle.close()
+                            return
+                print("Download finished")
+                import zipfile
+                with zipfile.ZipFile(temp_zip_path) as zf:
+                    print("Extracting zip to", os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower()))
+                    zf.extractall(os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower()))
 
-                self.asset['thumbnail'] = bpy.data.images.load(thumbnailpath_low)
-                self.asset['thumbnail'].name = '.LOL_preview'
-
-                img = self.asset['thumbnail']
-                if bpy.app.version < (2, 83, 0):
-                    # Needed in old Blender versions so the images are not too dark
-                    img.colorspace_settings.name = 'Linear'
-
-            except ConnectionError as error:
-                print("Connection error: Could not download " + imagename)
-                print(error)
             except TimeoutError as error:
-                print("TimeoutError error: Could not download " + imagename)
+                print("TimeoutError error: Could not download " + filename)
                 print(error)
-            except urllib.error.HTTPError as error:
-                print("HTTPError error: Could not download " + imagename)
-                print(error)
+            except urllib.error.URLError as error:
+                print("Could not download: " + filename)
 
             finally:
                 tcom.finished = True
-                try:
-                    url_handle.close()
-                except NameError:
-                    pass
-        else:
-            #Asset download
-            filename = self.asset["url"]
-
-            with tempfile.TemporaryDirectory() as temp_dir_path:
-                temp_zip_path = os.path.join(temp_dir_path, filename)
-                url = LOL_HOST_URL + "/" + tcom.passargs['asset type'].lower() + "/" + filename
-                try:
-                    print("Downloading:", url)
-
-                    with urllib.request.urlopen(url, timeout=60) as url_handle, \
-                            open(temp_zip_path, "wb") as file_handle:
-                        total_length = url_handle.headers.get('Content-Length')
-                        tcom.file_size = int(total_length)
-
-                        dl = 0
-                        data = url_handle.read(8192)
-                        file_handle.write(data)
-                        while len(data) == 8192:
-                            data = url_handle.read(8192)
-                            dl += len(data)
-                            tcom.downloaded = dl
-                            tcom.progress = int(100 * tcom.downloaded / tcom.file_size)
-
-                            # Stop download if Blender is closed
-                            for thread in threading.enumerate():
-                                if isinstance(thread, _MainThread):
-                                    if not thread.is_alive():
-                                        self.stop()
-
-                            file_handle.write(data)
-                            if self.stopped():
-                                url_handle.close()
-                                return
-                    print("Download finished")
-                    import zipfile
-                    with zipfile.ZipFile(temp_zip_path) as zf:
-                        print("Extracting zip to", os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower()))
-                        zf.extractall(os.path.join(user_preferences.global_dir, tcom.passargs['asset type'].lower()))
-
-                except TimeoutError as error:
-                    print("TimeoutError error: Could not download " + filename)
-                    print(error)
-                except urllib.error.URLError as error:
-                    print("Could not download: " + filename)
-
-                finally:
-                    tcom.finished = True
 
 
 class ThreadCom:  # object passed to threads to read background process stdout info
@@ -686,8 +621,18 @@ def clean_previmg(fullsize=False):
 
 
 def load_previews(context, asset_type):
-    name = basename(dirname(dirname(dirname(__file__))))
-    user_preferences = context.preferences.addons[name].preferences
+    global bg_threads
+    bg_task = Thread(target=bg_load_previews, args=(context, asset_type))
+    bg_threads.append(["bg_load_previews", bg_task])
+    bg_task.start()
+
+
+def bg_load_previews(context, asset_type):
+    global bg_threads
+    from queue import Queue
+    download_queue = Queue()
+
+    user_preferences = get_addon_preferences(bpy.context)
 
     if asset_type == 'MODEL':
         assets = context.scene.luxcoreOL.model['assets']
@@ -697,44 +642,41 @@ def load_previews(context, asset_type):
         assets = context.scene.luxcoreOL.material['assets']
 
     clean_previmg()
-    if assets is not None and len(assets) != 0:
-        for asset in assets:
-            if asset_type == 'MATERIAL':
-                imagename = asset['name'].replace(" ", "_") + '.jpg'
-            else:
-                imagename = splitext(asset['url'])[0] + '.jpg'
 
-            tpath_full = join(user_preferences.global_dir, asset_type, 'preview', 'full', imagename)
-            tpath = join(user_preferences.global_dir, asset_type, 'preview', imagename)
+    for asset in assets:
+        if asset_type == 'MATERIAL':
+            imagename = asset['name'].replace(" ", "_") + '.jpg'
+        else:
+            imagename = splitext(asset['url'])[0] + '.jpg'
 
-            if os.path.exists(tpath_full) and os.path.getsize(tpath_full) > 0 and \
-                    os.path.exists(tpath) and os.path.getsize(tpath) > 0:
+        tpath_full = join(user_preferences.global_dir, asset_type.lower(), 'preview', 'full', imagename)
+        tpath = join(user_preferences.global_dir, asset_type.lower(), 'preview', imagename)
+
+        if exists(tpath_full) and getsize(tpath_full) > 0 and \
+                exists(tpath) and getsize(tpath) > 0:
+            img = bpy.data.images.load(tpath)
+            img.name = '.LOL_preview'
+            asset["thumbnail"] = img
+
+            if bpy.app.version < (2, 83, 0):
+                # Needed in old Blender versions so the images are not too dark
+                img.colorspace_settings.name = 'Linear'
+        else:
+            if exists(tpath) and getsize(tpath) > 0:
+                print('Copy and downscale: ', imagename)
                 img = bpy.data.images.load(tpath)
-                img.name = '.LOL_preview'
-
-                asset["thumbnail"] = img
-
-                if bpy.app.version < (2, 83, 0):
-                    # Needed in old Blender versions so the images are not too dark
-                    img.colorspace_settings.name = 'Linear'
-            else:
-                if os.path.exists(tpath) and os.path.getsize(tpath) > 0:
-                    print('Copy and downscale: ', imagename)
+                if img.size == (128, 128):
+                    img.name = '.LOL_preview'
+                else:
+                    from shutil import copyfile
+                    copyfile(tpath, tpath_full)
                     img = bpy.data.images.load(tpath)
-                    if img.size == (128, 128):
-                        img.name = '.LOL_preview'
-                    else:
-                        from shutil import copyfile
-                        copyfile(tpath, tpath_full)
-                        img = bpy.data.images.load(tpath)
-                        img.scale(128, 128)
-                        img.save()
-                        bpy.data.images.remove(img)
+                    img.scale(128, 128)
+                    img.save()
+                    bpy.data.images.remove(img)
 
-                        asset['thumbnail'] = bpy.data.images.load(tpath)
-                        asset['thumbnail'].name = '.LOL_preview'
-
-
+                    asset['thumbnail'] = bpy.data.images.load(tpath)
+                    asset['thumbnail'].name = '.LOL_preview'
 
                 rootdir = dirname(dirname(dirname(__file__)))
                 path = join(rootdir, 'thumbnails', 'thumbnail_notready.jpg')
@@ -746,5 +688,57 @@ def load_previews(context, asset_type):
                     img.colorspace_settings.name = 'Linear'
 
                 asset["thumbnail"] = img
-                if not asset['local']:
-                    download_thumbnail(None, context, asset)
+            else:
+                download_queue.put((asset_type, imagename, asset))
+
+    bg_task = Thread(target=bg_download_thumbnails, args=(context, download_queue))
+    bg_threads.append(["bg_download_thumbnails", bg_task])
+    bg_task.start()
+
+    for threaddata in bg_threads:
+        tag, bg_task = threaddata
+        if tag == "bg_load_previews":
+            bg_threads.remove(threaddata)
+
+
+def bg_download_thumbnails(context, download_queue):
+    from requests import Session
+    session = Session()
+
+    name = basename(dirname(dirname(dirname(__file__))))
+    user_preferences = context.preferences.addons[name].preferences
+
+    while not download_queue.empty():
+        # Stop download if Blender is closed
+        for thread in threading.enumerate():
+            if isinstance(thread, _MainThread):
+                if not thread.is_alive():
+                    break
+
+        asset_type, imagename, asset = download_queue.get()
+
+        tpath_full = join(user_preferences.global_dir, asset_type.lower(), 'preview', 'full', imagename)
+        tpath = join(user_preferences.global_dir, asset_type.lower(), 'preview', imagename)
+
+        print("Downloading ", imagename)
+        url = LOL_HOST_URL + "/"+ asset_type.lower() +"/preview/" + imagename
+        with session.get(url) as resp, open(tpath, "wb") as file_handle:
+            if resp.status_code == 200:
+                file_handle.write(resp.content)
+
+                from shutil import copyfile
+                copyfile(tpath, tpath_full)
+                img = bpy.data.images.load(tpath)
+                img.scale(128, 128)
+                img.save()
+                bpy.data.images.remove(img)
+
+                asset['thumbnail'] = bpy.data.images.load(tpath)
+                asset['thumbnail'].name = '.LOL_preview'
+            else:
+                print("Download error ",resp.status_code, ": ", url)
+
+    for threaddata in bg_threads:
+        tag, bg_task = threaddata
+        if tag == "bg_download_thumbnails":
+            bg_threads.remove(threaddata)

--- a/utils/lol/utils.py
+++ b/utils/lol/utils.py
@@ -457,7 +457,8 @@ def link_asset(context, asset, location, rotation):
     # Objects have to be linked to show up in a scene
     for obj in data_to.objects:
         if not link_model:
-            obj.data.make_local()
+            if obj.data != None:
+                obj.data.make_local()
             parent = obj
             while parent.parent != None:
                 parent = parent.parent


### PR DESCRIPTION
With new python version in Blender 3.0 keyword parameters are mandatory to name. This is fixes an error when enabling the addon. There could be more places to fix.