### PR TITLE
Fix Pointer node

### DIFF
--- a/nodes/materials/tree.py
+++ b/nodes/materials/tree.py
@@ -163,7 +163,7 @@ luxcore_node_categories_material = [
         NodeItem("LuxCoreNodeTexIrregularData", label="Irregular Data"),
     ]),
 
-LuxCoreNodeCategoryMaterial("LUXCORE_MATERIAL_SHAPE", "Shape Modifiers", items=[
+    LuxCoreNodeCategoryMaterial("LUXCORE_MATERIAL_SHAPE", "Shape Modifiers", items=[
         NodeItem("LuxCoreNodeShapeSubdiv", label="Subdivision"),
         NodeItem("LuxCoreNodeShapeHeightDisplacement", label="Height Displacement"),
         NodeItem("LuxCoreNodeShapeVectorDisplacement", label="Vector Displacement"),

--- a/operators/pointer_node.py
+++ b/operators/pointer_node.py
@@ -42,11 +42,10 @@ class LUXCORE_MT_pointer_select_node_tree(bpy.types.Menu, LUXCORE_MT_node_tree):
     bl_idname = "LUXCORE_MT_pointer_select_node_tree"
     bl_description = "Select a node tree"
 
-    @classmethod
-    def poll(cls, context):
-        return poll_node(context)
-
     def draw(self, context):
+        if not hasattr(context, "node"):
+            # this shouldn't happen, because draw is only called when the menu is open
+            return
         node = context.node
         assert node.bl_idname == "LuxCoreNodeTreePointer"
         self.custom_draw(node.filter, "luxcore.pointer_set_node_tree")


### PR DESCRIPTION
Fixes #770 Pointer node does not allow selecting a material, volume, or texture

The `LUXCORE_MT_pointer_select_node_tree` menu is calling `poll_node` from its `@poll` class method, and it seems to always return `False` because when it is called `context` has no attribute `node`. I don't know why this stopped working, or even if it ever did.

Returning `False` from `poll` causes the Pointer node to not show the drop-down menu at all, making it impossible to use the Pointer node at all.

![image](https://user-images.githubusercontent.com/5019658/164199293-648eb527-91ed-473b-90da-7d021827682a.png)


To fix this, we can remove the `poll` method (same thing as always returning `True`, and instead check that the `node` is present in the `draw` method, before we try to use it.

![image](https://user-images.githubusercontent.com/5019658/164199716-d7b7f5a0-6493-4483-80b7-70c6ac113188.png)
