### PR TITLE
Update Use PhotonGI Cache material option hints

### DIFF
--- a/nodes/materials/output.py
+++ b/nodes/materials/output.py
@@ -102,18 +102,23 @@ class LuxCoreNodeMatOutput(bpy.types.Node, LuxCoreNodeOutput):
         row.prop(self, "shadow_color", text="")
         row.label(text="Shadow Color")
 
+        # PhotonGI
+        photongi_enabled = context.scene.luxcore.config.photongi.enabled
+        col = box.column()
+        col.active = photongi_enabled
+        if not photongi_enabled:
+            col.label(text="PhotonGI Cache is not enabled", icon=icons.INFO)
+
+        row = col.row()
+        row.active = photongi_enabled
+        row.prop(self, "use_photongi")
+
         # All of the options below only work with the Path engine, not with Bidir
         engine = context.scene.luxcore.config.engine
         col = box.column()
         col.active = engine == "PATH"
         if engine == "BIDIR":
             col.label(text="Not supported by Bidir engine:", icon=icons.INFO)
-
-        # PhotonGI
-        row = col.row()
-        row.active = (context.scene.luxcore.config.photongi.enabled
-                      and engine == "PATH")
-        row.prop(self, "use_photongi")
 
         # Holdout
         col.prop(self, "is_holdout")


### PR DESCRIPTION
Fixes #773 PhotonGI Cache material option showing as unavailable when engine is BiDir

Since LuxCore 2.6: BIDIRCPU can now use PhotonGI caustic cache to render SDS paths

The Material Output node renders the **Use PhotonGI Cache** option disabled, and shows an incorrect message stating that it's not available with the bi-directional engine.

This commit moves the **Use PhotonGI Cache** option up above this check, and now instead displays a message if PhotonGI Cache is not enabled.

### Scenarios:

| Engine | PhotonGI Cache | SS    |
|--------|----------------|-------|
| PATH   | Disabled       | ![image](https://user-images.githubusercontent.com/5019658/168601920-f92916dc-e0c3-4d5d-b430-0e85eb4887e9.png) |
| PATH   | Enabled        | ![image](https://user-images.githubusercontent.com/5019658/168602010-c131b619-b950-4146-aa4a-c2e66c9ca42c.png) |
| BIDIR  | Disabled       | ![image](https://user-images.githubusercontent.com/5019658/168602106-a945e074-1c53-41ae-b79a-2574836213fe.png) |
| BIDIR  | Enabled        | ![image](https://user-images.githubusercontent.com/5019658/168602200-245db690-2085-4c63-87ee-d014c062cdd3.png) |