### PR TITLE
Bump version number; User-Agent for urllib Request

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,8 +16,8 @@ if bpy.app.version < (2, 93, 0):
     raise Exception("\n\nUnsupported Blender version. 2.93 or higher is required by BlendLuxCore.")
 
 if platform.system() == "Darwin":
-    if bpy.app.version < (2, 82, 7):
-        raise Exception("\n\nUnsupported Blender version. 2.82a or higher is required.")
+    if bpy.app.version < (4, 2, 0):
+        raise Exception("\n\nUnsupported Blender version. 4.2 or higher is required.")
     mac_version = tuple(map(int, platform.mac_ver()[0].split(".")))
     if mac_version < (10, 9, 0):
         raise Exception("\n\nUnsupported Mac OS version. 10.9 or higher is required.")
@@ -31,7 +31,7 @@ if platform.system() in {"Linux", "Darwin"}:
 bl_info = {
     "name": "LuxCoreRender",
     "author": "Simon Wendsche (B.Y.O.B.), Michael Klemm (neo2068), Odilkhan Yakubov (odil24), acasta69, u3dreal, Philstix",
-    "version": (2, 9),
+    "version": (2, 10),
     "blender": (4, 2, 0),
     "category": "Render",
     "description": "LuxCoreRender integration for Blender",

--- a/operators/lol/update_ToC.py
+++ b/operators/lol/update_ToC.py
@@ -27,6 +27,11 @@ from os.path import basename, dirname, join, isfile, splitext
 
 from bpy.types import Operator
 from ...utils.lol import utils as utils
+from ... import bl_info
+
+blc_ver = '.'.join([str(_) for _ in bl_info["version"]])
+useragent = f"BlendLuxCore/{blc_ver}" # user agent for urllib request to LOL
+
 
 
 class LOLUpdateTOC(Operator):
@@ -50,7 +55,11 @@ class LOLUpdateTOC(Operator):
 
         filepath = join(user_preferences.global_dir, 'assets_model_blendermarket.json')
         urlstr = utils.LOL_HOST_URL + "/" + utils.LOL_VERSION + "/assets_model_blendermarket.json"
-        with urllib.request.urlopen(urlstr, timeout=60) as request:
+
+        req = urllib.request.Request(
+            urlstr, data=None, headers={'User-Agent': useragent}
+        )
+        with urllib.request.urlopen(req, timeout=60) as request:
             assets = json.load(request)
 
             with open(filepath, 'w') as file:
@@ -58,7 +67,11 @@ class LOLUpdateTOC(Operator):
 
         filepath = join(user_preferences.global_dir, 'assets_model.json')
         urlstr = utils.LOL_HOST_URL + "/" + utils.LOL_VERSION + "/assets_model.json"
-        with urllib.request.urlopen(urlstr, timeout=60) as request:
+        
+        req = urllib.request.Request(
+            urlstr, data=None, headers={'User-Agent': useragent}
+        )
+        with urllib.request.urlopen(req, timeout=60) as request:
             assets = json.load(request)
 
             with open(filepath, 'w') as file:
@@ -66,7 +79,11 @@ class LOLUpdateTOC(Operator):
 
         filepath = join(user_preferences.global_dir, 'assets_material.json')
         urlstr = utils.LOL_HOST_URL + "/" + utils.LOL_VERSION + "/assets_material.json"
-        with urllib.request.urlopen(urlstr, timeout=60) as request:
+        
+        req = urllib.request.Request(
+            urlstr, data=None, headers={'User-Agent': useragent}
+        )
+        with urllib.request.urlopen(req, timeout=60) as request:
             assets = json.load(request)
 
             with open(filepath, 'w') as file:


### PR DESCRIPTION
Urllib was not sending a User-Agent by default, causing LOL downloads to fail on the new webhosting.
Introducting a custom user agent, currently "BlendLuxCore/2.10".

Could be added to new wheels download system as well for consistency, pending tests.