### PR TITLE
fix: LuxCore is now supported for Blender 5.0.0

### DIFF
--- a/draw/viewport.py
+++ b/draw/viewport.py
@@ -1,4 +1,3 @@
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -59,7 +58,6 @@ class FrameBuffer(object):
 
         self._transparent = self._initialize_transparency(scene, context)
         bufferdepth = 4 if self._transparent else 3
-        self._buffertype = bgl.GL_RGBA if self._transparent else bgl.GL_RGB
         self._output_type = (
             pyluxcore.FilmOutputType.RGBA_IMAGEPIPELINE
             if self._transparent else

--- a/handlers/draw_imageeditor.py
+++ b/handlers/draw_imageeditor.py
@@ -1,6 +1,5 @@
 import bpy
 import blf
-from bgl import *
 import gpu
 from gpu_extras.batch import batch_for_shader
 


### PR DESCRIPTION
Fix for the following [issue](https://github.com/LuxCoreRender/BlendLuxCore/issues/1044).