### PR TITLE
Add network rendering improvements for macOS Apple Silicon

### DIFF
--- a/export/__init__.py
+++ b/export/__init__.py
@@ -12,6 +12,7 @@ from . import (
 )
 from .light import WORLD_BACKGROUND_LIGHT_NAME
 from .caches.object_cache import supports_live_transform
+from .image import network_texture_manager
 
 
 class Change:
@@ -88,6 +89,11 @@ class Exporter(object):
         # the user has linked/appended assets with node trees from previous versions of
         # the addon since opening the .blend file.
         utils_compatibility.run()
+
+        # Initialize network texture manager for filesaver export
+        # This must be done before any image exports
+        if context is None:  # Only for final render
+            network_texture_manager.setup(scene)
 
         # Scene
         image_resize_policy_props = scene.luxcore.config.image_resize_policy.convert()

--- a/export/image.py
+++ b/export/image.py
@@ -1,7 +1,177 @@
 import bpy
 import tempfile
 import os
+import shutil
+import hashlib
 from .. import utils
+
+
+class NetworkTextureManager(object):
+    """
+    Manages texture file collection and path remapping for network rendering.
+    When enabled, textures are either:
+    - Copied to a 'textures' subdirectory in the export path with relative paths
+    - Referenced with relative paths (if they're already in a subdirectory of export path)
+    """
+    _instance = None
+    
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+    
+    def __init__(self):
+        if self._initialized:
+            return
+        self._initialized = True
+        self.reset()
+    
+    def reset(self):
+        """Reset state for a new export"""
+        self.enabled = False
+        self.copy_textures = False
+        self.use_relative_paths = False
+        self.export_dir = None
+        self.textures_dir = None
+        self.copied_files = {}  # Maps source path -> destination relative path
+        self.path_mappings = {}  # Maps absolute path -> path to use in scene file
+    
+    def setup(self, scene):
+        """
+        Configure the texture manager based on scene settings.
+        Call this at the start of export.
+        """
+        self.reset()
+        config = scene.luxcore.config
+        
+        if not config.use_filesaver:
+            return
+        
+        self.copy_textures = config.filesaver_copy_textures
+        self.use_relative_paths = config.filesaver_use_relative_paths
+        self.enabled = self.copy_textures or self.use_relative_paths
+        
+        if not self.enabled:
+            return
+        
+        # Determine the export directory (base path only, the full path with
+        # blend name subdirectory will be created when first needed)
+        filesaver_path = config.filesaver_path
+        try:
+            base_path = utils.get_abspath(filesaver_path, must_exist=True, must_be_existing_dir=True)
+        except OSError:
+            print("[NetworkTextureManager] Warning: Filesaver path does not exist, disabling texture management")
+            self.enabled = False
+            return
+        
+        # Add blend file name subdirectory (same logic as _convert_filesaver in config.py)
+        blend_name = utils.get_blendfile_name()
+        if not blend_name:
+            blend_name = "Untitled"
+        dir_name = blend_name + "_LuxCore"
+        self.export_dir = os.path.join(base_path, dir_name)
+        
+        if self.copy_textures:
+            self.textures_dir = os.path.join(self.export_dir, "textures")
+    
+    def get_unique_filename(self, source_path):
+        """
+        Generate a unique filename for a texture to avoid collisions.
+        Uses a short hash of the original path + original filename.
+        """
+        basename = os.path.basename(source_path)
+        name, ext = os.path.splitext(basename)
+        
+        # Create a short hash from the full path to ensure uniqueness
+        path_hash = hashlib.md5(source_path.encode()).hexdigest()[:8]
+        
+        return f"{name}_{path_hash}{ext}"
+    
+    def process_path(self, absolute_path):
+        """
+        Process a texture path for network rendering.
+        Returns the path to use in the scene file.
+        
+        If copy_textures is enabled, copies the file and returns relative path.
+        If only use_relative_paths is enabled, tries to make path relative.
+        """
+        if not self.enabled or not absolute_path:
+            return absolute_path
+        
+        # Check if we've already processed this path
+        if absolute_path in self.path_mappings:
+            return self.path_mappings[absolute_path]
+        
+        # Normalize the path
+        absolute_path = os.path.normpath(os.path.abspath(absolute_path))
+        
+        if self.copy_textures:
+            result_path = self._copy_and_get_relative_path(absolute_path)
+        elif self.use_relative_paths:
+            result_path = self._try_make_relative(absolute_path)
+        else:
+            result_path = absolute_path
+        
+        self.path_mappings[absolute_path] = result_path
+        return result_path
+    
+    def _copy_and_get_relative_path(self, source_path):
+        """Copy file to textures directory and return relative path"""
+        if not os.path.exists(source_path):
+            print(f"[NetworkTextureManager] Warning: Source file not found: {source_path}")
+            return source_path
+        
+        # Ensure textures directory exists
+        if not os.path.exists(self.textures_dir):
+            os.makedirs(self.textures_dir, exist_ok=True)
+        
+        # Generate unique destination filename
+        unique_name = self.get_unique_filename(source_path)
+        dest_path = os.path.join(self.textures_dir, unique_name)
+        
+        # Copy the file if not already copied
+        if source_path not in self.copied_files:
+            try:
+                shutil.copy2(source_path, dest_path)
+                print(f"[NetworkTextureManager] Copied: {source_path} -> {dest_path}")
+                self.copied_files[source_path] = dest_path
+            except Exception as e:
+                print(f"[NetworkTextureManager] Error copying {source_path}: {e}")
+                return source_path
+        
+        # Return relative path from export directory
+        return os.path.join("textures", unique_name)
+    
+    def _try_make_relative(self, absolute_path):
+        """Try to make the path relative to the export directory"""
+        try:
+            rel_path = os.path.relpath(absolute_path, self.export_dir)
+            # Only use relative path if it doesn't go up too many directories
+            if not rel_path.startswith(".."):
+                return rel_path
+        except ValueError:
+            # On Windows, relpath fails if paths are on different drives
+            pass
+        return absolute_path
+    
+    def finalize(self):
+        """
+        Called at the end of export to report statistics and cleanup.
+        """
+        if not self.enabled:
+            return
+        
+        if self.copied_files:
+            print(f"[NetworkTextureManager] Copied {len(self.copied_files)} texture files to {self.textures_dir}")
+        
+        if self.path_mappings:
+            relative_count = sum(1 for p in self.path_mappings.values() if not os.path.isabs(p))
+            print(f"[NetworkTextureManager] {relative_count} paths converted to relative")
+
+
+# Global instance
+network_texture_manager = NetworkTextureManager()
 
 
 class ImageExporter(object):
@@ -51,16 +221,21 @@ class ImageExporter(object):
 
     @classmethod
     def export(cls, image, image_user, scene):
+        """
+        Export an image and return the filepath to use in the scene.
+        If network texture management is enabled, handles copying/path remapping.
+        """
+        filepath = None
+        
         if image.source == "GENERATED":
-            return cls._save_to_temp_file(image)
+            filepath = cls._save_to_temp_file(image)
         elif image.source == "FILE":
             if image.packed_file:
-                return cls._save_to_temp_file(image)
+                filepath = cls._save_to_temp_file(image)
             else:
                 try:
                     filepath = utils.get_abspath(image.filepath, library=image.library,
                                                  must_exist=True, must_be_existing_file=True)
-                    return filepath
                 except OSError as error:
                     # Make the error message more precise
                     raise OSError('Could not find image "%s" at path "%s" (%s)'
@@ -77,32 +252,46 @@ class ImageExporter(object):
                 if frame < 1:
                     raise IndexError
                 index, filepath = indexed_filepaths[frame - 1]
-                return filepath
             except IndexError:
                 raise OSError('Frame %d in image sequence "%s" does not exist (contains only %d frames)'
                               % (frame, image.name, len(indexed_filepaths)))
         else:
             raise Exception('Unsupported image source "%s" in image "%s"' % (image.source, image.name))
+        
+        # Process path through network texture manager if enabled
+        if filepath:
+            filepath = network_texture_manager.process_path(filepath)
+        
+        return filepath
 
     @classmethod
     def export_cycles_node_reader(cls, image):
-        # TODO deduplicate code, support image sequences
+        """
+        Export for cycles node reader - similar to export() but without image_user.
+        """
+        filepath = None
+        
         if image.source == "GENERATED":
-            return cls._save_to_temp_file(image)
+            filepath = cls._save_to_temp_file(image)
         elif image.source == "FILE":
             if image.packed_file:
-                return cls._save_to_temp_file(image)
+                filepath = cls._save_to_temp_file(image)
             else:
                 try:
                     filepath = utils.get_abspath(image.filepath, library=image.library,
                                                  must_exist=True, must_be_existing_file=True)
-                    return filepath
                 except OSError as error:
                     # Make the error message more precise
                     raise OSError('Could not find image "%s" at path "%s" (%s)'
                                   % (image.name, image.filepath, error))
         else:
             raise Exception('Unsupported image source "%s" in image "%s"' % (image.source, image.name))
+        
+        # Process path through network texture manager if enabled
+        if filepath:
+            filepath = network_texture_manager.process_path(filepath)
+        
+        return filepath
 
     @classmethod
     def cleanup(cls):
@@ -113,4 +302,7 @@ class ImageExporter(object):
             os.remove(filepath)
 
         cls.temp_images.clear()
+        
+        # Also finalize network texture manager
+        network_texture_manager.finalize()
 

--- a/export/imagepipeline.py
+++ b/export/imagepipeline.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import pyluxcore
 from .. import utils
-from .image import ImageExporter
+from .image import ImageExporter, network_texture_manager
 from ..utils.errorlog import LuxCoreErrorLog
 
 
@@ -216,6 +216,8 @@ def _camera_response_func(definitions, index, camera_response_func, scene):
             library = scene.camera.data.library
             name = utils.get_abspath(camera_response_func.file, library,
                                      must_exist=True, must_be_existing_file=True)
+            # Process through network texture manager for network rendering
+            name = network_texture_manager.process_path(name)
         except OSError as error:
             # Make the error message more precise
             LuxCoreErrorLog.add_warning('Could not find .crf file at path "%s" (%s)'
@@ -238,6 +240,8 @@ def _color_LUT(definitions, index, color_LUT, scene):
         library = scene.camera.data.library
         filepath = utils.get_abspath(color_LUT.file, library,
                                      must_exist=True, must_be_existing_file=True)
+        # Process through network texture manager for network rendering
+        filepath = network_texture_manager.process_path(filepath)
     except OSError as error:
         # Make the error message more precise
         LuxCoreErrorLog.add_warning('Could not find .cube file at path "%s" (%s)'

--- a/export/light.py
+++ b/export/light.py
@@ -4,7 +4,7 @@ import math
 import pyluxcore
 from .. import utils
 from .caches.exported_data import ExportedObject, ExportedLight
-from .image import ImageExporter
+from .image import ImageExporter, network_texture_manager
 from ..utils.errorlog import LuxCoreErrorLog
 from ..utils import node as utils_node
 from ..nodes.output import get_active_output
@@ -946,6 +946,8 @@ def export_ies(definitions, ies, library, is_meshlight=False):
         if iesfile:
             try:
                 filepath = utils.get_abspath(iesfile, library, must_exist=True, must_be_existing_file=True)
+                # Process through network texture manager for network rendering
+                filepath = network_texture_manager.process_path(filepath)
                 definitions[prefix + "iesfile"] = filepath
             except OSError as error:
                 # Make the error message more precise

--- a/nodes/textures/fresnel.py
+++ b/nodes/textures/fresnel.py
@@ -6,6 +6,7 @@ from ...ui import icons
 from ... import utils
 from ...utils.errorlog import LuxCoreErrorLog
 from ...utils import node as utils_node
+from ...export.image import network_texture_manager
 
 
 class LuxCoreNodeTexFresnel(LuxCoreNodeTexture, bpy.types.Node):
@@ -84,6 +85,8 @@ class LuxCoreNodeTexFresnel(LuxCoreNodeTexture, bpy.types.Node):
             #Fresnel data file
             try:
                 filepath = utils.get_abspath(self.filepath, must_exist=True, must_be_existing_file=True)
+                # Process through network texture manager for network rendering
+                filepath = network_texture_manager.process_path(filepath)
 
                 definitions = {
                     "file": filepath,

--- a/operators/pyluxcoretools.py
+++ b/operators/pyluxcoretools.py
@@ -7,7 +7,7 @@ from shutil import which
 
 class LUXCORE_OT_install_pyside(bpy.types.Operator):
     bl_idname = "luxcore.install_pyside"
-    bl_label = "You need PySide. Install it now?"
+    bl_label = "You need PySide6. Install it now?"
     bl_description = ""
 
     def invoke(self, context, event):
@@ -16,18 +16,19 @@ class LUXCORE_OT_install_pyside(bpy.types.Operator):
 
     def execute(self, context):
         threadcount = context.scene.render.threads
-        install_command = 'sudo pip3 install --install-option="--jobs=%d" PySide' % threadcount
+        # Try PySide6 first (recommended for Python 3.10+), fall back to PySide2
+        install_command = 'pip3 install PySide6 || pip3 install PySide2'
 
         if not which("x-terminal-emulator"):
-            self.report({"ERROR"}, "Could not open terminal. Please install PySide by hand:")
-            self.report({"ERROR"}, install_command)
+            self.report({"ERROR"}, "Could not open terminal. Please install PySide6 by hand:")
+            self.report({"ERROR"}, "pip3 install PySide6")
             self.report({"ERROR"}, "(You can copy the command from the terminal)")
-            print(install_command)
+            print("pip3 install PySide6")
             return {"CANCELLED"}
 
         script = (
             "'"
-            + 'echo "This will install PySide (required by pyluxcoretools UI)";'
+            + 'echo "This will install PySide6 (required by pyluxcoretools UI)";'
             # Show which command will be used to install PySide
             + 'echo "' + install_command.replace('"', '\\"') + '";'
             # Execute the command to install PySide
@@ -41,6 +42,30 @@ class LUXCORE_OT_install_pyside(bpy.types.Operator):
         return {"FINISHED"}
 
 
+def _check_pyside_installed():
+    """
+    Check if PySide6 or PySide2 is installed.
+    Returns tuple: (is_installed: bool, version: str or None)
+    """
+    try:
+        result = run(["pip3", "list"], stdout=PIPE, stderr=PIPE)
+        installed_packages = result.stdout.decode()
+        
+        # Check for PySide6 first (preferred for Python 3.10+)
+        if "PySide6" in installed_packages:
+            return True, "PySide6"
+        # Fall back to PySide2
+        if "PySide2" in installed_packages:
+            return True, "PySide2"
+        # Also check for just "PySide" (older versions)
+        if "PySide" in installed_packages:
+            return True, "PySide"
+        
+        return False, None
+    except FileNotFoundError:
+        return False, None
+
+
 class LUXCORE_OT_start_pyluxcoretools(bpy.types.Operator):
     bl_idname = "luxcore.start_pyluxcoretools"
     bl_label = "LuxCore Network Render"
@@ -51,23 +76,17 @@ class LUXCORE_OT_start_pyluxcoretools(bpy.types.Operator):
         my_env = os.environ.copy()
 
         if platform.system() == "Darwin":
-            # MacOS does not come with Python3 most installation methods supply
-            # a symbolic link to /usr/local/bin or /usr/local/sbin
-            my_env["PATH"] = "/usr/local/bin:/usr/local/sbin:" + my_env.get("PATH", "")
+            # macOS: add common Python installation paths
+            # Support Homebrew on both Intel (/usr/local) and Apple Silicon (/opt/homebrew)
+            my_env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:" + my_env.get("PATH", "")
 
             try:
-                result = run(["pip3", "list"], env=my_env, stdout=PIPE)
-                installed_packages = result.stdout.decode()
-            except FileNotFoundError:
-                msg = "pip3 not installed, see wiki for instructions"
-                self.report({"WARNING"}, msg)
-                bpy.ops.luxcore.open_website_popup("INVOKE_DEFAULT",
-                                                   message=msg,
-                                                   url="https://wiki.luxcorerender.org/LuxCoreRender_Network_Rendering")
-                return {"CANCELLED"}
+                is_installed, pyside_version = _check_pyside_installed()
+            except Exception:
+                is_installed, pyside_version = False, None
 
-            if "PySide2" not in installed_packages:
-                msg = "PySide2 not installed, see wiki for instructions"
+            if not is_installed:
+                msg = "PySide6 or PySide2 not installed. Install with: pip3 install PySide6"
                 self.report({"WARNING"}, msg)
                 bpy.ops.luxcore.open_website_popup("INVOKE_DEFAULT",
                                                    message=msg,
@@ -78,10 +97,9 @@ class LUXCORE_OT_start_pyluxcoretools(bpy.types.Operator):
             # On Linux, PySide can not be bundled because of this bug:
             # https://github.com/LuxCoreRender/LuxCore/issues/80#issuecomment-378223152
             # So we need to check if PySide is installed, and install it if necessary
-            result = run(["pip3", "list"], stdout=PIPE)
-            installed_packages = result.stdout.decode()
+            is_installed, pyside_version = _check_pyside_installed()
 
-            if "PySide" not in installed_packages:
+            if not is_installed:
                 bpy.ops.luxcore.install_pyside("INVOKE_DEFAULT")
                 return {"CANCELLED"}
 

--- a/properties/config.py
+++ b/properties/config.py
@@ -550,6 +550,20 @@ class LuxCoreConfig(PropertyGroup):
     ]
     filesaver_format: EnumProperty(name="", items=filesaver_format_items, default="TXT")
     filesaver_path: StringProperty(name="", subtype="DIR_PATH", description="Output path where the scene is saved")
+    
+    # Network rendering options
+    filesaver_copy_textures: BoolProperty(
+        name="Copy Textures",
+        default=False,
+        description="Copy all texture files to the export directory. Essential for network rendering "
+                    "where render nodes may have different filesystem paths"
+    )
+    filesaver_use_relative_paths: BoolProperty(
+        name="Use Relative Paths",
+        default=False,
+        description="Store texture paths relative to the export directory instead of absolute paths. "
+                    "When enabled with 'Copy Textures', textures are stored in a 'textures' subdirectory"
+    )
 
     # Seed
     seed: IntProperty(name="Seed", default=1, min=1, description=SEED_DESC)

--- a/ui/render/__init__.py
+++ b/ui/render/__init__.py
@@ -33,6 +33,7 @@ classes = (
     image_resize_policy.LUXCORE_RENDER_PT_image_resize_policy,
     tools.LUXCORE_RENDER_PT_tools,
     tools.LUXCORE_RENDER_PT_filesaver,
+    tools.LUXCORE_RENDER_PT_filesaver_network,
     viewport.LUXCORE_RENDER_PT_viewport_settings,
     viewport.LUXCORE_RENDER_PT_viewport_settings_denoiser,
     viewport.LUXCORE_RENDER_PT_viewport_settings_advanced,

--- a/ui/render/tools.py
+++ b/ui/render/tools.py
@@ -56,3 +56,29 @@ class LUXCORE_RENDER_PT_filesaver(RenderButtonsPanel, Panel):
         col = layout.column(align=True)
         col.prop(config, "filesaver_format")
         col.prop(config, "filesaver_path")
+
+
+class LUXCORE_RENDER_PT_filesaver_network(RenderButtonsPanel, Panel):
+    COMPAT_ENGINES = {"LUXCORE"}
+    bl_label = "Network Rendering Options"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_parent_id = "LUXCORE_RENDER_PT_filesaver"
+
+    @classmethod
+    def poll(cls, context):
+        config = context.scene.luxcore.config
+        return config.use_filesaver
+
+    def draw(self, context):
+        layout = self.layout
+        config = context.scene.luxcore.config
+
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        col = layout.column(align=True)
+        col.prop(config, "filesaver_copy_textures")
+        col.prop(config, "filesaver_use_relative_paths")
+        
+        if config.filesaver_copy_textures and config.filesaver_use_relative_paths:
+            layout.label(text="Textures will be copied to 'textures/' subdirectory", icon=icons.INFO)


### PR DESCRIPTION
- Add PySide6 support (with PySide2 fallback) for Python 3.13 compatibility
- Add Apple Silicon Homebrew path support (/opt/homebrew/bin)
- Add NetworkTextureManager for texture path handling in network renders
- Add UI options to copy textures and use relative paths in Filesaver
- Process IES, LUT, CRF, and NK file paths through texture manager
- Enable cross-platform network rendering between macOS and Ubuntu nodes