### PR TITLE
code quality: improve cmake/blendluxcore_version.py and draw/__init__.py

### DIFF
--- a/cmake/blendluxcore_version.py
+++ b/cmake/blendluxcore_version.py
@@ -1,15 +1,20 @@
+#!/usr/bin/env python3
 """Retrieve BlendLuxCore version from blender_manifest.toml"""
 import tomllib
-import os
 from pathlib import Path
 import argparse
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("filepath", type=Path)
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filepath", type=Path)
+    args = parser.parse_args()
 
-with open(args.filepath, 'rb') as fp:
-    manifest = tomllib.load(fp)
-version = manifest['version']
-print(version, end='')
+    with open(args.filepath, 'rb') as fp:
+        manifest = tomllib.load(fp)
+    version = manifest['version']
+    print(version, end='')
+
+
+if __name__ == "__main__":
+    main()

--- a/draw/__init__.py
+++ b/draw/__init__.py
@@ -5,10 +5,9 @@ from . import final
 from . import viewport
 from . import utils
 
-
 if _needs_reload:
     import importlib
-
+    # Reload submodules when bpy has been cached (developer reload)
     importlib.reload(final)
     importlib.reload(viewport)
     importlib.reload(utils)


### PR DESCRIPTION
## Summary
- **cmake/blendluxcore_version.py**:
  - Add shebang `#!/usr/bin/env python3` for CLI executability
  - Remove unused `import os` statement
  - Wrap logic in `main()` function for proper script structure
  - Guard with `if __name__ == "__main__"` for import safety
  
- **draw/__init__.py**:
  - Add clarifying comment explaining the `_needs_reload` mechanism for Blender addon development

## Test plan
- [ ] Verify `cmake/blendluxcore_version.py` runs correctly as a standalone script
- [ ] Verify the addon still loads correctly in Blender (the reload guard is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)