### PR TITLE
Fix #1091: Prevent legacy Principled BSDF from rendering as mesh lights

### DIFF
--- a/export/cycles_node_reader.py
+++ b/export/cycles_node_reader.py
@@ -171,8 +171,32 @@ def _node(node, output_socket, props, material, luxcore_name=None, obj_name="", 
                 }
         
         # Attach these props to the right-most material node (regardless if it's glass, disney or a mix mat)
+
+        # Fix for issue #1091: Only add emission if actually used
+        # Blender 3.6 uses "Emission", Blender 4.0+ renamed it to "Emission Color"
+        emission_color_socket_name = "Emission Color" if "Emission Color" in node.inputs else "Emission"
+        emission_color_socket = node.inputs[emission_color_socket_name]
+        emission_strength_socket = node.inputs["Emission Strength"]
+
+        emission_update = {}
+        color_is_linked = emission_color_socket.is_linked
+        strength_is_linked = emission_strength_socket.is_linked
+        color_default = list(emission_color_socket.default_value)[:3]
+        color_is_nonzero = any(c > 0 for c in color_default)
+        strength_is_nonzero = emission_strength_socket.default_value > 0
+
+        if color_is_linked or strength_is_linked or (color_is_nonzero and strength_is_nonzero):
+            emission_color = _socket(emission_color_socket, props, material, obj_name, group_node_stack)
+            emission_strength = _socket(emission_strength_socket, props, material, obj_name, group_node_stack)
+            emission_tex_name = luxcore_name + "_em"
+            props.Set(utils.luxutils.create_props(
+                "scene.textures." + emission_tex_name + ".",
+                {"type": "scale", "texture1": emission_strength, "texture2": emission_color},
+            ))
+            emission_update["emission"] = emission_tex_name
+
         definitions.update({
-            "emission": _socket(node.inputs["Emission Strength"], props, material, obj_name, group_node_stack),
+            **emission_update,
             "transparency": _socket(node.inputs["Alpha"], props, material, obj_name, group_node_stack),
             "bumptex": _socket(node.inputs["Normal"], props, material, obj_name, group_node_stack),
         })


### PR DESCRIPTION
Legacy Principled BSDF materials from older Blender versions were incorrectly exported with emission=1, causing them to render as mesh lights instead of regular materials.

Root cause:
- Unconditionally read "Emission Strength" socket (default value 1.0)
- No check if emission was actually used/linked
- Blender 3.6 uses "Emission", Blender 4.0+ uses "Emission Color"

Solution:
- Detect socket name (Emission vs Emission Color) for version compatibility
- Check if emission color/strength is linked OR has non-zero values
- Only export emission property when genuinely needed
- Combine color * strength using scale texture

Impact:
- Linked assets from older Blender versions now render correctly
- No false mesh light conversions
- Backward compatible with all Blender versions

Fixes #1091